### PR TITLE
JIRA: ABC-132 Adjusting start value of time range in AlembicStreamPlayer slighly changes the end value

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
-- Fixed a bug that caused unintended end of range stream edits.
+- Fixed an issue where changing the start value of the streaming time range would slightly change the end of range value.
 
 ## [2.2.0-pre.4] - 2021-04-27
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fixed a bug that caused unintended end of range stream edits.
 
 ## [2.2.0-pre.4] - 2021-04-27
 ### Added

--- a/com.unity.formats.alembic/Editor/Importer/AlembicStreamPlayerEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicStreamPlayerEditor.cs
@@ -164,8 +164,15 @@ namespace UnityEditor.Formats.Alembic.Importer
                 EditorGUILayout.MinMaxSlider(" ", ref start, ref end, abcStart, abcEnd);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    startTime.doubleValue = start;
-                    endTime.doubleValue = end;
+                    if (Math.Abs(startTime.doubleValue - start) > 1e-5) // The Mix max slider is "jiggly": changes slightly all numbers even though they were not changed.
+                    {
+                        startTime.doubleValue = start;
+                    }
+
+                    if (Math.Abs(endTime.doubleValue - end) > 1e-5)
+                    {
+                        endTime.doubleValue = end;
+                    }
                 }
 
                 EditorGUILayout.BeginHorizontal();


### PR DESCRIPTION
Bug caused by slight inaccuracies of the MinMaxSlider widget.