### PR TITLE
JIRA: ABC-224 Alembic Motion vectors persist when the model is not being updated

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
-- Fixed a bug that caused visual artefacts when pausing Alembic playback. 
+- Fixed a bug that was causing visual artefacts due to motion vector persistence when pausing Alembic playback.
 
 ## [2.2.0-pre.4] - 2021-04-27
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fixed a bug that caused visual artefacts when pausing Alembic playback. 
 
 ## [2.2.0-pre.4] - 2021-04-27
 ### Added

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -192,10 +192,25 @@ namespace UnityEngine.Formats.Alembic.Importer
             if (m_streamInterupted)
                 return;
 
-
             m_context.updateJobHandle.Complete();
             AbcBeginSyncData(m_abcTreeRoot);
             AbcEndSyncData(m_abcTreeRoot);
+        }
+
+        public void ClearMotionVectors()
+        {
+            ClearMotionVectors(m_abcTreeRoot);
+        }
+
+        void ClearMotionVectors(AlembicTreeNode node)
+        {
+            if (node.abcObject is AlembicMesh mesh)
+            {
+                mesh.ClearMotionVectors();
+            }
+
+            foreach (var child in node.Children)
+                ClearMotionVectors(child);
         }
 
         public bool AbcLoad(bool createMissingNodes, bool serializeMesh)

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -351,7 +351,12 @@ namespace UnityEngine.Formats.Alembic.Importer
                 Update();
 
             if (!updateStarted)
+            {
+                // If the model did not move this frame, we need to clear the motion vectors to avoid post processing artefacts.
+                abcStream.ClearMotionVectors();
                 return;
+            }
+
             updateStarted = false;
             abcStream.AbcUpdateEnd();
         }

--- a/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Formats.Alembic.Importer;
+using UnityEngine.TestTools;
+
+namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
+{
+    public class GenericRuntime
+    {
+#if UNITY_EDITOR
+        [UnityTest]
+        public IEnumerator VelocitiesAreReset_WhenPlaybackIsPaused([Values("a6d019a425afe49d7a8fd029c82c0455", "d0f12062215204c6991895f6a51dd627")] string guid)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            var asset = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            var go = PrefabUtility.InstantiatePrefab(asset) as GameObject;
+            var player = go.GetComponent<AlembicStreamPlayer>();
+            var mesh = player.GetComponentInChildren<MeshFilter>().sharedMesh;
+            player.CurrentTime = 1 / 60f;
+            yield return null;
+            var velocity = new List<Vector3>();
+            mesh.GetUVs(5, velocity);
+
+            Assert.IsTrue(velocity.Any(x => x != Vector3.zero));
+            yield return new WaitForEndOfFrame();
+            mesh.GetUVs(5, velocity);
+            Assert.IsTrue(velocity.All(x => x == Vector3.zero));
+        }
+#endif
+    }
+}

--- a/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs
@@ -29,6 +29,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             mesh.GetUVs(5, velocity);
             Assert.IsTrue(velocity.All(x => x == Vector3.zero));
         }
+
 #endif
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs.meta
+++ b/com.unity.formats.alembic/Tests/Runtime/GenericRuntime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 18f459dd26824b7f8920396685ab6f06
+timeCreated: 1622739535


### PR DESCRIPTION
Before:
If a frame included a time change update the mesh including velocity
If a frame had no time change early out, causing motion vectors to persist

after:
If a frame included a time change update the mesh including velocity
If a frame had no time update, zero out the mesh velocity once.

@cguer 
Compare the velocities inside HDRP of a cube that moves and then stops in the middle of a screen with the same skinned cube recorded as alembic.