### PR TITLE
JIRA: ABC-171 Automatically resize Alembic clips to the animation length on creation

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for importing the cage mesh of SubD Alembic nodes.
 
 ### Changed
+-  Automatically set the timeline clip length when dragging an AlembicStreamPlayer onto a timeline Alembic track.
 ### Fixed
 
 ## [2.2.0] - 2021-06-10

--- a/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
@@ -29,9 +29,7 @@ namespace UnityEditor.Formats.Alembic.Importer
 #else
             var fps = TimelineEditor.inspectedAsset.editorSettings.fps;
 #endif
-            double duration =
-                Math.Max(asp.Duration, 1 / fps); // at least 1 frame
-            clip.duration = duration;
+            clip.duration = asp.Duration > 1 / fps ? asp.Duration : 1; // Clips that are under 1 frame are 1s long (tiny clips are hard to select in the UI)
         }
     }
 }

--- a/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEditor.Timeline;
+using UnityEngine;
+using UnityEngine.Formats.Alembic.Importer;
+using UnityEngine.Formats.Alembic.Timeline;
+using UnityEngine.Timeline;
+
+namespace UnityEditor.Formats.Alembic.Importer
+{
+    [CustomTimelineEditor(typeof(AlembicShotAsset))]
+    class AlembicShotAssetEditor : ClipEditor
+    {
+        public override void OnCreate(TimelineClip clip, TrackAsset track, TimelineClip clonedFrom)
+        {
+            if (TimelineEditor.inspectedDirector == null || TimelineEditor.inspectedAsset == null || clonedFrom != null)
+            {
+                return;
+            }
+
+            var asset = clip.asset as AlembicShotAsset;
+            var asp = TimelineEditor.inspectedDirector.GetReferenceValue(asset.StreamPlayer.exposedName,
+                out var valid) as AlembicStreamPlayer;
+            if (asp == null || !valid)
+            {
+                return;
+            }
+
+            var duration =
+                Math.Max(asp.Duration, 1 / TimelineEditor.inspectedAsset.editorSettings.frameRate); // at least 1 frame
+            clip.duration = duration;
+        }
+    }
+}

--- a/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEditor.Timeline;
-using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Formats.Alembic.Timeline;
 using UnityEngine.Timeline;
@@ -25,8 +24,13 @@ namespace UnityEditor.Formats.Alembic.Importer
                 return;
             }
 
-            var duration =
-                Math.Max(asp.Duration, 1 / TimelineEditor.inspectedAsset.editorSettings.frameRate); // at least 1 frame
+#if TIMELINE_1_6_0
+            var fps = TimelineEditor.inspectedAsset.editorSettings.frameRate;
+#else
+            var fps = TimelineEditor.inspectedAsset.editorSettings.fps;
+#endif
+            double duration =
+                Math.Max(asp.Duration, 1 / fps); // at least 1 frame
             clip.duration = duration;
         }
     }

--- a/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs.meta
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicShotAssetEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba8ac38765e914669bcf267763ae8698
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.formats.alembic/Editor/Unity.Formats.Alembic.Editor.asmdef
+++ b/com.unity.formats.alembic/Editor/Unity.Formats.Alembic.Editor.asmdef
@@ -21,6 +21,11 @@
             "name": "com.unity.recorder",
             "expression": "2.2.0-preview.1",
             "define": "RECORDER_AVAILABLE"
+        },
+        {
+            "name": "com.unity.timeline",
+            "expression": "1.6.0-pre.5",
+            "define": "TIMELINE_1_6_0"
         }
     ],
     "noEngineReferences": false

--- a/com.unity.formats.alembic/Editor/Unity.Formats.Alembic.Editor.asmdef
+++ b/com.unity.formats.alembic/Editor/Unity.Formats.Alembic.Editor.asmdef
@@ -1,9 +1,11 @@
 {
     "name": "Unity.Formats.Alembic.Editor",
+    "rootNamespace": "",
     "references": [
         "Unity.Formats.Alembic.Runtime",
         "Unity.Timeline",
-        "Unity.Recorder.Editor"
+        "Unity.Recorder.Editor",
+        "Unity.Timeline.Editor"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
When dragging an alembic stream player onto a timeline alembic track, the length of the clip should be the same as a the StreamPlayer's duration:

@cguer strange cases to test:
* Duplicate a clip should preserve source length.
* Mess with clip in Timeline asset mode 
* Drag a clip that has only 1 frame
* Test mechanism when inside subtimelines.
* Importerless StreamPlayer