### PR TITLE
JIRA: ABC-94 World scaling ignored on Unity cloth export

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+- Fixed a bug that caused Unity Cloth alembic export to ignore the world scale.
 
 ## [2.2.0] - 2021-06-10
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
-- Fixed a bug that caused Unity Cloth alembic export to ignore the world scale.
+- Fixed a bug that caused Unity Cloth Alembic export to ignore the world scale.
 
 ## [2.2.0] - 2021-06-10
 ### Added

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -455,7 +455,14 @@ namespace UnityEngine.Formats.Alembic.Util
                 // apply root bone transform
                 if (rootBone != null)
                 {
-                    var mat = Matrix4x4.TRS(rootBone.localPosition, rootBone.localRotation, Vector3.one);
+                    var mat = Matrix4x4.TRS(rootBone.position, rootBone.rotation, Vector3.one);
+                    // The Cloth disregards the world scale (Similar to the SkinnedMesh).
+                    if (rootBone.parent != null)
+                    {
+                        mat = Matrix4x4.TRS(Vector3.zero, Quaternion.identity, rootBone.parent.lossyScale).inverse *
+                            mat;
+                    }
+
                     NativeMethods.aeApplyMatrixP(vertices, vertices.Count, ref mat);
                     NativeMethods.aeApplyMatrixV(normals, normals.Count, ref mat);
                 }

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         protected GameObject camera;
         const string sceneName = "Scene";
 
-        protected GameObject TestAbcImported(string abcPath, double minDuration = 0.1)
+        protected GameObject TestAbcImported(string abcPath, double minDuration = 0)
         {
             AssetDatabase.Refresh();
             Assert.That(File.Exists(abcPath));
@@ -46,6 +46,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             {
                 yield return null;
             }
+            exporter.EndRecording();
         }
 
         protected static bool NearlyEqual(float f1, float f2, float eps = 1e-5f)

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         protected GameObject camera;
         const string sceneName = "Scene";
 
-        protected GameObject TestAbcImported(string abcPath, double minDuration = 0)
+        protected GameObject TestAbcImported(string abcPath, double minDuration = 0.1)
         {
             AssetDatabase.Refresh();
             Assert.That(File.Exists(abcPath));
@@ -46,7 +46,6 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             {
                 yield return null;
             }
-            exporter.EndRecording();
         }
 
         protected static bool NearlyEqual(float f1, float f2, float eps = 1e-5f)

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         protected GameObject camera;
         const string sceneName = "Scene";
 
-        protected GameObject TestAbcImported(string abcPath, double minDuration = 0.1)
+        protected GameObject TestAbcImported(string abcPath, double minDuration = 0)
         {
             AssetDatabase.Refresh();
             Assert.That(File.Exists(abcPath));
@@ -29,7 +29,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.That(go, Is.Not.Null);
 
             var player = go.GetComponent<AlembicStreamPlayer>();
-            Assert.GreaterOrEqual(player.Duration, minDuration); // More than empty
+            Assert.Greater(player.Duration, minDuration); // More than empty
 
             return go;
         }

--- a/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/BaseFixture.cs
@@ -17,7 +17,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         protected GameObject camera;
         const string sceneName = "Scene";
 
-        protected GameObject TestAbcImported(string abcPath, double minDuration = 0)
+        protected GameObject TestAbcImported(string abcPath, double minDuration = 0.1)
         {
             AssetDatabase.Refresh();
             Assert.That(File.Exists(abcPath));
@@ -29,7 +29,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.That(go, Is.Not.Null);
 
             var player = go.GetComponent<AlembicStreamPlayer>();
-            Assert.Greater(player.Duration, minDuration); // More than empty
+            Assert.GreaterOrEqual(player.Duration, minDuration); // More than empty
 
             return go;
         }

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -56,25 +56,5 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestPlaneContents(go);
         }
-
-        [UnityTest]
-        public IEnumerator TestClothWorldScaling()
-        {
-            var clothRoot = new GameObject("Root");
-            cloth.transform.parent = clothRoot.transform;
-            clothRoot.transform.localScale = new Vector3(0.5f, 1, 1);
-            clothRoot.transform.localEulerAngles = new Vector3(0, 33, 0);
-
-            yield return RecordAlembic();
-
-            var prefab = TestAbcImported(exporter.Recorder.Settings.OutputPath);
-            var go  = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
-            var player = go.GetComponent<AlembicStreamPlayer>();
-
-            player.UpdateImmediately(0);
-            var meshFilter = go.GetComponentsInChildren<MeshFilter>().First(x => x.name == "Plane");
-
-            Assert.That(new Vector3(-8.17750168f, -0.0186390355f, 5.110888f), Is.EqualTo(meshFilter.sharedMesh.vertices[0]).Within(1e-5));
-        }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -9,6 +9,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 {
     class ClothTests : BaseFixture
     {
+        private Cloth cloth;
         static IEnumerator TestPlaneContents(GameObject go)
         {
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
@@ -42,7 +43,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             sphere.transform.localPosition = new Vector3(0, -1, 0);
             var plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
-            var cloth = plane.AddComponent<Cloth>();
+            cloth = plane.AddComponent<Cloth>();
             cloth.sphereColliders = new[] {new ClothSphereColliderPair(sphere.GetComponent<SphereCollider>())};
             cloth.clothSolverFrequency = 300;
         }
@@ -54,6 +55,26 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
             var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
             yield return TestPlaneContents(go);
+        }
+
+        [UnityTest]
+        public IEnumerator TestClothWorldScaling()
+        {
+            var clothRoot = new GameObject("Root");
+            cloth.transform.parent = clothRoot.transform;
+            clothRoot.transform.localScale = new Vector3(0.5f, 1, 1);
+            clothRoot.transform.localEulerAngles = new Vector3(0, 33, 0);
+
+            yield return RecordAlembic();
+
+            var prefab = TestAbcImported(exporter.Recorder.Settings.OutputPath);
+            var go  = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
+            var player = go.GetComponent<AlembicStreamPlayer>();
+
+            player.UpdateImmediately(0);
+            var meshFilter = go.GetComponentsInChildren<MeshFilter>().First(x => x.name == "Plane");
+
+            Assert.That(new Vector3(-8.17750168f, -0.0186390355f, 5.110888f), Is.EqualTo(meshFilter.sharedMesh.vertices[0]).Within(1e-5));
         }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -9,20 +9,49 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 {
     class ClothTests : BaseFixture
     {
-        static IEnumerator TestPlaneContents(GameObject go)
+        private GameObject clothRoot;
+
+        [SetUp]
+        public new void SetUp()
+        {
+            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            sphere.transform.localPosition = new Vector3(0, -1, 0);
+            var plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            var cloth = plane.AddComponent<Cloth>();
+            cloth.sphereColliders = new[] {new ClothSphereColliderPair(sphere.GetComponent<SphereCollider>())};
+            cloth.clothSolverFrequency = 300;
+
+            clothRoot = new GameObject("Root");
+            cloth.transform.parent = clothRoot.transform;
+            clothRoot.transform.localScale = new Vector3(0.5f, 1, 1);
+            clothRoot.transform.localEulerAngles = new Vector3(0, 33, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator TestDefaultExportParams()
+        {
+            yield return RecordAlembic();
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
+            TestPlaneContents(go);
+        }
+
+        void TestPlaneContents(GameObject go)
         {
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
             var player = root.GetComponent<AlembicStreamPlayer>();
 
             var meshFilter = root.GetComponentsInChildren<MeshFilter>().First(x => x.name == "Plane");
-            player.CurrentTime = 0;
-            yield return new WaitForEndOfFrame();
+            player.UpdateImmediately(0);
             var vt0 = meshFilter.sharedMesh.vertices[0];
             var vCount0 = meshFilter.sharedMesh.vertices.Length;
             var idxCount0 = meshFilter.sharedMesh.GetIndexCount(0);
             var subMeshCount0 = meshFilter.sharedMesh.subMeshCount;
-            player.CurrentTime = (float)player.Duration;
-            yield return new WaitForEndOfFrame();
+
+            Assert.That(meshFilter.sharedMesh.vertices[0],
+                Is.EqualTo(new Vector3(-1.41f, -0.02f, 2.04f)).Within(0.1));
+
+            player.UpdateImmediately(0.6f);
             var vt1 = meshFilter.sharedMesh.vertices[0];
             var vCount1 = meshFilter.sharedMesh.vertices.Length;
             var idxCount1 = meshFilter.sharedMesh.GetIndexCount(0);
@@ -34,26 +63,6 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.AreEqual(vCount0, vCount1);
             Assert.AreEqual(idxCount0, idxCount1);
             Assert.AreEqual(subMeshCount0, subMeshCount1);
-        }
-
-        [SetUp]
-        public new void SetUp()
-        {
-            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            sphere.transform.localPosition = new Vector3(0, -1, 0);
-            var plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
-            var cloth = plane.AddComponent<Cloth>();
-            cloth.sphereColliders = new[] {new ClothSphereColliderPair(sphere.GetComponent<SphereCollider>())};
-            cloth.clothSolverFrequency = 300;
-        }
-
-        [UnityTest]
-        public IEnumerator TestDefaultExportParams()
-        {
-            yield return RecordAlembic();
-            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
-            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
-            yield return TestPlaneContents(go);
         }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/ClothTests.cs
@@ -9,49 +9,20 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 {
     class ClothTests : BaseFixture
     {
-        private GameObject clothRoot;
-
-        [SetUp]
-        public new void SetUp()
-        {
-            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-            sphere.transform.localPosition = new Vector3(0, -1, 0);
-            var plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
-            var cloth = plane.AddComponent<Cloth>();
-            cloth.sphereColliders = new[] {new ClothSphereColliderPair(sphere.GetComponent<SphereCollider>())};
-            cloth.clothSolverFrequency = 300;
-
-            clothRoot = new GameObject("Root");
-            cloth.transform.parent = clothRoot.transform;
-            clothRoot.transform.localScale = new Vector3(0.5f, 1, 1);
-            clothRoot.transform.localEulerAngles = new Vector3(0, 33, 0);
-        }
-
-        [UnityTest]
-        public IEnumerator TestDefaultExportParams()
-        {
-            yield return RecordAlembic();
-            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
-            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
-            TestPlaneContents(go);
-        }
-
-        void TestPlaneContents(GameObject go)
+        static IEnumerator TestPlaneContents(GameObject go)
         {
             var root = PrefabUtility.InstantiatePrefab(go) as GameObject;
             var player = root.GetComponent<AlembicStreamPlayer>();
 
             var meshFilter = root.GetComponentsInChildren<MeshFilter>().First(x => x.name == "Plane");
-            player.UpdateImmediately(0);
+            player.CurrentTime = 0;
+            yield return new WaitForEndOfFrame();
             var vt0 = meshFilter.sharedMesh.vertices[0];
             var vCount0 = meshFilter.sharedMesh.vertices.Length;
             var idxCount0 = meshFilter.sharedMesh.GetIndexCount(0);
             var subMeshCount0 = meshFilter.sharedMesh.subMeshCount;
-
-            Assert.That(meshFilter.sharedMesh.vertices[0],
-                Is.EqualTo(new Vector3(-1.41f, -0.02f, 2.04f)).Within(0.1));
-
-            player.UpdateImmediately(0.6f);
+            player.CurrentTime = (float)player.Duration;
+            yield return new WaitForEndOfFrame();
             var vt1 = meshFilter.sharedMesh.vertices[0];
             var vCount1 = meshFilter.sharedMesh.vertices.Length;
             var idxCount1 = meshFilter.sharedMesh.GetIndexCount(0);
@@ -63,6 +34,26 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.AreEqual(vCount0, vCount1);
             Assert.AreEqual(idxCount0, idxCount1);
             Assert.AreEqual(subMeshCount0, subMeshCount1);
+        }
+
+        [SetUp]
+        public new void SetUp()
+        {
+            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            sphere.transform.localPosition = new Vector3(0, -1, 0);
+            var plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            var cloth = plane.AddComponent<Cloth>();
+            cloth.sphereColliders = new[] {new ClothSphereColliderPair(sphere.GetComponent<SphereCollider>())};
+            cloth.clothSolverFrequency = 300;
+        }
+
+        [UnityTest]
+        public IEnumerator TestDefaultExportParams()
+        {
+            yield return RecordAlembic();
+            deleteFileList.Add(exporter.Recorder.Settings.OutputPath);
+            var go = TestAbcImported(exporter.Recorder.Settings.OutputPath);
+            yield return TestPlaneContents(go);
         }
     }
 }


### PR DESCRIPTION
The world scale was ignored by the cloth exporter (Similar to the previous skinned mesh issue.)

Deleted the unit test cause I could not find a way to make the Cloth simulation deterministic 