### PR TITLE
Make the format jobs depend on the Pack

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -265,6 +265,8 @@ format_check_osx:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
     - unity-downloader-cli -u 2019.4 -c Editor
     - utr/utr --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
+  dependencies:
+    - .yamato/upm-ci.yml#pack       
   artifacts:
     logs.zip:
       paths:
@@ -280,6 +282,8 @@ format_check_win:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
     - unity-downloader-cli -u 2019.4 -c Editor
     - utr/utr.bat --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
+  dependencies:
+    - .yamato/upm-ci.yml#pack         
   artifacts:
     logs.zip:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -340,7 +340,7 @@ nightly_test_trigger:
   name: Nightly tests Trigger
   triggers:
     recurring:
-      - branch: trunk
+      - branch: main
         frequency: daily
         rerun: always    
   dependencies:


### PR DESCRIPTION
The formatting jobs can fail at times because the alembic importer cannot import the packaged alembic files (the build job for the platform did not finish).

This change makes the Formatting checks depend on the Pack step to guarantee that the native libs are always available.