### PR TITLE
JIRA: ABC-264 Fix for 2.3.X: Replacing streamed alembic with same hie…

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Prevented material assignments from being lost for a streamed external Alembic file when changing the Alembic source file link.
 
 ## [2.2.1] - 2021-07-10
 ### Added

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStreamPlayer.cs
@@ -262,13 +262,14 @@ namespace UnityEngine.Formats.Alembic.Importer
                 }
 
                 var subMesh = mesh.subMeshCount;
-                var mats = new Material[subMesh];
+                var newMats = new Material[subMesh];
+                var oldMats = meshRenderer.sharedMaterials;
                 for (var i = 0; i < subMesh; ++i)
                 {
-                    mats[i] = defaultMat;
+                    newMats[i] = i < oldMats.Length && oldMats[i] != null ? oldMats[i] : defaultMat;
                 }
 
-                meshRenderer.sharedMaterials = mats;
+                meshRenderer.sharedMaterials = newMats;
             });
 
             return true;

--- a/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
@@ -368,5 +368,34 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 
             Assert.IsTrue(true); // should not have Thrown exceptions
         }
+
+        [Test]
+        public void StreamedAlembicFilesKeepMaterialAssignmentsWhenChangingStream()
+        {
+            const string dst = "Assets/dst.abc";
+            var src = AssetDatabase.GUIDToAssetPath("1a066d124049a413fb12b82470b82811");
+            File.Copy(src, dst);
+            deleteFileList.Add(dst);
+            var player = new GameObject().AddComponent<AlembicStreamPlayer>();
+            player.LoadFromFile(src);
+            var mat = AlembicMesh.GetDefaultMaterial();
+            var renderer = player.GetComponentInChildren<MeshRenderer>();
+            renderer.material = mat;
+
+            Assert.AreEqual(mat, renderer.sharedMaterial);
+
+            player.LoadFromFile(dst);
+            Assert.AreEqual(mat, renderer.sharedMaterial);
+        }
+
+        static AlembicStreamPlayer LoadAndInstantiate(string guid)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            var asset = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            var go = PrefabUtility.InstantiatePrefab(asset) as GameObject;
+            var player = go.GetComponent<AlembicStreamPlayer>();
+
+            return player;
+        }
     }
 }


### PR DESCRIPTION
…rarchy removes material assignments (#471)

* JIRA: ABC-264 Fix for 2.2.X: Replacing streamed alembic with same hierarchy removes material assignments