### PR TITLE
JIRA: ABC-267 Exception when applying import preset on Alembic file with different hierarchy

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fixed a bug that caused imports to fail when material mapping data is inconsistent with Alembic node hirarchy.
 
 ## [2.3.0-pre.1] - 2021-07-11
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
-- Fixed a bug that caused imports to fail when material mapping data is inconsistent with Alembic node hirarchy.
+- Prevent import failure when material mapping data is inconsistent with Alembic node hierarchy.
 
 ## [2.3.0-pre.1] - 2021-07-11
 ### Added

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
@@ -15,7 +16,7 @@ using static UnityEditor.AssetDatabase;
 using UnityEditor.Experimental.AssetImporters;
 using static UnityEditor.Experimental.AssetDatabaseExperimental;
 #endif
-
+[assembly: InternalsVisibleTo("Unity.Formats.Alembic.UnitTests.Editor")]
 namespace UnityEditor.Formats.Alembic.Importer
 {
     class AlembicAssetModificationProcessor : AssetModificationProcessor
@@ -254,8 +255,18 @@ namespace UnityEditor.Formats.Alembic.Importer
                 var materialId = Int32.Parse(pathFaceId[1]);
 
                 var meshGO = GetGameObjectFromPath(go, path);
+                if (meshGO == null)
+                {
+                    continue;
+                }
+
                 var renderer = meshGO.GetComponent<MeshRenderer>();
                 var mats = renderer.sharedMaterials;
+                if (materialId > mats.Length - 1)
+                {
+                    continue;
+                }
+
                 mats[materialId] = r.Value as Material;
                 renderer.sharedMaterials = mats;
             }
@@ -321,7 +332,7 @@ namespace UnityEditor.Formats.Alembic.Importer
 
                 if (!found)
                 {
-                    throw new Exception($"Cannot find path:{path} from GameObject: {root.name}");
+                    return null;
                 }
             }
 

--- a/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using UnityEditor.Formats.Alembic.Importer;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Importer;
 using UnityEngine.Formats.Alembic.Sdk;
@@ -435,6 +436,48 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 
             player.LoadFromFile(dst);
             Assert.AreEqual(mat, renderer.sharedMaterial);
+        }
+
+        [Test]
+        public void ImporterAcceptsMismatchedGameObjectPathPathMapping()
+        {
+            const string dst = "Assets/src.abc";
+            const string matPath = "Assets/mat.mat";
+            var src = AssetDatabase.GUIDToAssetPath("1a066d124049a413fb12b82470b82811");
+            File.Copy(src, dst);
+            var mat = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(mat, matPath);
+            deleteFileList.Add(dst);
+            deleteFileList.Add(matPath);
+            AssetDatabase.ImportAsset(dst, ImportAssetOptions.ForceSynchronousImport);
+            var importer =  AssetImporter.GetAtPath(dst) as AlembicImporter;
+            importer.AddRemap(new AssetImporter.SourceAssetIdentifier(typeof(Material), "some/random/path:999:SomeName"), mat);
+            AssetDatabase.ImportAsset(dst, ImportAssetOptions.ForceSynchronousImport);
+
+            var mesh = AssetDatabase.LoadAssetAtPath<GameObject>(dst).GetComponentInChildren<MeshFilter>();
+
+            Assert.IsNotNull(mesh);
+        }
+
+        [Test]
+        public void ImporterAcceptsMismatchedFacesetNames()
+        {
+            const string dst = "Assets/src.abc";
+            const string matPath = "Assets/mat.mat";
+            var src = AssetDatabase.GUIDToAssetPath("1a066d124049a413fb12b82470b82811");
+            File.Copy(src, dst);
+            var mat = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(mat, matPath);
+            deleteFileList.Add(dst);
+            deleteFileList.Add(matPath);
+            AssetDatabase.ImportAsset(dst, ImportAssetOptions.ForceSynchronousImport);
+            var importer =  AssetImporter.GetAtPath(dst) as AlembicImporter;
+            importer.AddRemap(new AssetImporter.SourceAssetIdentifier(typeof(Material), "backflip (FFFFFB70)/Man_Sample (FFFFFB6C)/Man_Sample (FFFFFB6A)/Man_Sample:099:submesh[0]"), mat);
+            AssetDatabase.ImportAsset(dst, ImportAssetOptions.ForceSynchronousImport);
+
+            var mesh = AssetDatabase.LoadAssetAtPath<GameObject>(dst).GetComponentInChildren<MeshFilter>();
+
+            Assert.IsNotNull(mesh);
         }
 
         static AlembicStreamPlayer LoadAndInstantiate(string guid)

--- a/com.unity.formats.alembic/Tests/Editor/Unity.Formats.Alembic.Editor.Tests.asmdef
+++ b/com.unity.formats.alembic/Tests/Editor/Unity.Formats.Alembic.Editor.Tests.asmdef
@@ -5,7 +5,8 @@
         "Unity.Formats.Alembic.Runtime",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Unity.Timeline"
+        "Unity.Timeline",
+        "Unity.Formats.Alembic.Editor"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
Fixed a bug where if an alembic file had a node hierarchy that is inconsistent with the material mapping, it would fail to reimport: eg file changed hierarchy, or a user applied the wrong preset.

This bug impacts only when using a feature introduced in the previous Pre version.