### PR TITLE
JIRA: ABC-283 Fix for 2.3.X: Package fails to compile when removing the analytics module from a project

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fixed a compile error when a project does not have the analytics module.
 
 ## [2.3.0-pre.3] - 2021-10-02
 ### Added

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0-pre.4] - 2022-01-02
+### Added
+### Changed
+### Fixed
+
 ## [2.3.0-pre.3] - 2021-10-02
 ### Added
 ### Changed

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.timeline": "1.0.0",
+    "com.unity.modules.unityanalytics": "1.0.0",
     "com.unity.modules.cloth": "1.0.0"
   },
   "description": "Import and export Alembic files (.abc), record and stream animations in the Alembic format directly in Unity.\nNOTE: Supported build platforms: only Windows 64, MacOS X, Linux 64, and Stadia.\n\nThe Alembic format is commonly used in animation to transfer facial, cloth, and other simulation between applications in the form of baked data.",

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -15,5 +15,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2019.4",
-  "version": "2.3.0-pre.3"
+  "version": "2.3.0-pre.4"
 }


### PR DESCRIPTION
The alembic package implemented analytics, but did not realize that thew analytics was in a separate module of the editor.

This PR adds a dependency on that module:


Steps can be found here: https://jira.unity3d.com/browse/ABC-283

@sebastienduverne Please validate only the changelog.