### PR TITLE
JIRA: ABC-290 Strip alembic behaviour instances when building unsupported targets.

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0-pre.4] - 2022-01-02
 ### Added
 ### Changed
-- When building unsupported standalone targets, the Alembic Components get stripped from the build. 
+- When building unsupported standalone targets, Unity excludes the Alembic components from the build.
 
 ### Fixed
 

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0-pre.4] - 2022-01-02
 ### Added
 ### Changed
+- When building unsupported standalone targets, the Alembic Components get stripped from the build. 
+
 ### Fixed
 
 ## [2.3.0-pre.3] - 2021-10-02

--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
@@ -16,6 +16,8 @@ namespace UnityEditor.Formats.Alembic.Importer
 {
     static class AlembicBuildPostProcess
     {
+        internal const string kUnsupportedTarget = "Alembic only supports the following build targets: Windows 64-bit, MacOS X, Linux 64-bit or Stadia.";
+
         internal static readonly HashSet<KeyValuePair<string, string>> FilesToCopy = new HashSet<KeyValuePair<string, string>>();
         internal static bool HaveAlembicInstances = false;
         [PostProcessBuild]
@@ -30,8 +32,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             {
                 if (HaveAlembicInstances)
                 {
-                    Debug.LogWarning(
-                        "Alembic only supports the following build targets: Windows 64-bit, MacOS X, Linux 64-bit or Stadia");
+                    Debug.LogWarning(kUnsupportedTarget);
                 }
 
                 HaveAlembicInstances = false;
@@ -69,12 +70,40 @@ namespace UnityEditor.Formats.Alembic.Importer
         }
     }
 
+    class AlembicScenePlayerStripper : IProcessSceneWithReport
+    {
+        static readonly Type[] kStrippableBehaviourTypes =
+        {
+            typeof(AlembicStreamPlayer),
+            typeof(AlembicCurves), typeof(AlembicCurvesRenderer), typeof(AlembicCustomData), typeof(AlembicPointsCloud), typeof(AlembicPointsRenderer)
+        };
+        
+        public int callbackOrder => -9999; // Run early to strip behaviours before other callbacks try to interact with them.
+
+        public void OnProcessScene(Scene scene, BuildReport report)
+        {
+            if (report == null || AlembicBuildPostProcess.TargetIsSupported(report.summary.platform))
+                return;
+
+            var sceneRoots = scene.GetRootGameObjects();
+            
+            var alembicBehaviours = new List<Component>();
+            foreach (var type in kStrippableBehaviourTypes)
+            {
+                alembicBehaviours.AddRange(sceneRoots.SelectMany(root => root.GetComponentsInChildren(type, true)));
+            }
+ 
+            if (alembicBehaviours.Count > 0)
+            {
+                Debug.Log($"{AlembicBuildPostProcess.kUnsupportedTarget} Stripping {alembicBehaviours.Count} alembic behaviour instances from scene '{scene.name}'.");
+                alembicBehaviours.ForEach(Object.DestroyImmediate);
+            }
+        }
+    }
+    
     class AlembicProcessScene : IProcessSceneWithReport
     {
-        public int callbackOrder
-        {
-            get { return 9999; } // Best if we are lest in the chain to catch potential Alembics that were created during a Scene post process.
-        }
+        public int callbackOrder => 9999; // Run late to catch potential Alembics that were created during a Scene post process.
 
         public void OnProcessScene(Scene scene, BuildReport report)
         {

--- a/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicBuildPostProcess.cs
@@ -75,9 +75,11 @@ namespace UnityEditor.Formats.Alembic.Importer
         static readonly Type[] kStrippableBehaviourTypes =
         {
             typeof(AlembicStreamPlayer),
-            typeof(AlembicCurves), typeof(AlembicCurvesRenderer), typeof(AlembicCustomData), typeof(AlembicPointsCloud), typeof(AlembicPointsRenderer)
+            typeof(AlembicCustomData),
+            typeof(AlembicCurvesRenderer), typeof(AlembicCurves),
+            typeof(AlembicPointsRenderer), typeof(AlembicPointsCloud),
         };
-        
+
         public int callbackOrder => -9999; // Run early to strip behaviours before other callbacks try to interact with them.
 
         public void OnProcessScene(Scene scene, BuildReport report)
@@ -86,13 +88,13 @@ namespace UnityEditor.Formats.Alembic.Importer
                 return;
 
             var sceneRoots = scene.GetRootGameObjects();
-            
+
             var alembicBehaviours = new List<Component>();
             foreach (var type in kStrippableBehaviourTypes)
             {
                 alembicBehaviours.AddRange(sceneRoots.SelectMany(root => root.GetComponentsInChildren(type, true)));
             }
- 
+
             if (alembicBehaviours.Count > 0)
             {
                 Debug.Log($"{AlembicBuildPostProcess.kUnsupportedTarget} Stripping {alembicBehaviours.Count} alembic behaviour instances from scene '{scene.name}'.");
@@ -100,7 +102,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             }
         }
     }
-    
+
     class AlembicProcessScene : IProcessSceneWithReport
     {
         public int callbackOrder => 9999; // Run late to catch potential Alembics that were created during a Scene post process.


### PR DESCRIPTION
Topic for discussion: Strip scene alembic data to avoid serialization issues from code missing at runtime (mismatching type sizes).