### PR TITLE
OSX Clear the quarantine flag for ispc when extracting

### DIFF
--- a/cmake/FindISPC.cmake
+++ b/cmake/FindISPC.cmake
@@ -19,6 +19,10 @@ set(ISPC_VERSION 1.14.1)
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMAND tar -xf ${CMAKE_SOURCE_DIR}/External/ispc/${ISPC_DIR}.tar.gz
         )
+        execute_process(
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMAND xattr -d com.apple.quarantine  ${CMAKE_SOURCE_DIR}/build/ispc-v1.14.1-macOS/bin/ispc
+        )
 
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         set(ISPC_DIR "ispc-v${ISPC_VERSION}-windows")


### PR DESCRIPTION
On local dev builds, OS-X complains about not being able to check that ispc is not malware and kills the process resulting in  a failed build.

This PR clears the quarantine flag on the ispc once came extracted the file.