### PR TITLE
JIRA:ABC-294 Fix for 2.3.X: [Switch]Unity Analytics errors detected when importing Alembic package

### DIFF
--- a/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
@@ -18,7 +18,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
 
         internal static void SendAnalytics(AlembicRecorderSettings settings)
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (!EditorAnalytics.enabled)
                 return;
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicStreamAnalytics.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicStreamAnalytics.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         internal static void SendAnalytics()
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS
             if (!EditorAnalytics.enabled)
                 return;
 


### PR DESCRIPTION
Apparently there are special requirements for analytics when building on Switch and other consoles.
When switching the build target to Switch for ex, the whole analytics module gets stripped out due to NDA requirements. This happens for all analytics that are collected inside a Runtime assembly.