### PR TITLE
JIRA: ABC-304 Change ubuntu test strategy

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -19,7 +19,7 @@ platforms:
 #    flavor: b1.large
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu-20
+    image: package-ci/ubuntu-20:stable
     flavor: b1.large
 
 
@@ -48,7 +48,7 @@ bizarro_standalone_platforms:
     flavor: b1.large
     runtime: standalone
   - name: ubuntu
-    type: Unity::VM
+    type: Unity::VM::GPU
     image: package-ci/ubuntu:stable
     flavor: b1.large
     runtime: standalone

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -19,7 +19,7 @@ platforms:
 #    flavor: b1.large
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-20
     flavor: b1.large
 
 
@@ -45,6 +45,11 @@ bizarro_standalone_platforms:
   - name: centOS
     type: Unity::VM::GPU
     image: package-ci/centos:latest
+    flavor: b1.large
+    runtime: standalone
+  - name: ubuntu
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
     flavor: b1.large
     runtime: standalone
   #- name: stadia


### PR DESCRIPTION
https://jira.unity3d.com/browse/ABC-304
I have put ubuntu image "package-ci/ubuntu-20:stable" under "platforms" and "package-ci/ubuntu:stable" under "bizarro_standalone_platforms". Tests have been run against my local branch and all passed.

I did meet a hiccup which is when putting "package-ci/ubuntu:stable" under bizarro, the VM type I chose had no GPU which always failed "Test Standalone on ubuntu". After I used GPU for standalone on Ubuntu, the test passed.
There were also two random failures "Test version trunk on mac" and "Test HDRP version 2021.1 on ubuntu" both of which passed after I rerun.