### PR TITLE
Disable hdrp test in trunk on Mac

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -236,6 +236,12 @@ test_trigger_hdrp:
     - .yamato/upm-ci.yml#pack
     {% for editor in editors %}
     {% for platform in platforms %}
+    {%- comment -%}
+    # Disable hdrp test in trunk on Mac for now which fails nightly trigger: First the test doesn't test too much. Second, we belive the failure is caused by HDRP in trunk
+    {%- endcomment -%}
+    {% if editor.version == 'trunk' and platform.name == 'mac' -%}
+    {% continue -%}
+    {% endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -237,7 +237,8 @@ test_trigger_hdrp:
     {% for editor in editors %}
     {% for platform in platforms %}
     {%- comment -%}
-    # Disable hdrp test in trunk on Mac for now which fails nightly trigger: First the test doesn't test too much. Second, we belive the failure is caused by HDRP in trunk
+    # Disable hdrp test in trunk on Mac for now which fails nightly trigger because: 
+    # First the test doesn't test too much. Second, we belive the failure is caused by HDRP in trunk
     {%- endcomment -%}
     {%- if editor.version == 'trunk' and platform.name == 'mac' -%}
     {%- continue -%}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -239,9 +239,9 @@ test_trigger_hdrp:
     {%- comment -%}
     # Disable hdrp test in trunk on Mac for now which fails nightly trigger: First the test doesn't test too much. Second, we belive the failure is caused by HDRP in trunk
     {%- endcomment -%}
-    {% if editor.version == 'trunk' and platform.name == 'mac' -%}
-    {% continue -%}
-    {% endif -%}
+    {%- if editor.version == 'trunk' and platform.name == 'mac' -%}
+    {%- continue -%}
+    {%- endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}


### PR DESCRIPTION
**Purpose of this change:**
HDRP test began to fail recently in trunk on Mac, but nothing has been changed on our side. 
The failure is because of the following warning message:
`warning: Assertion failed on expression: 'localPagePos <= page.allocatedSize'
`

We think we can just disable hdrp test in trunk on Mac for now based on:

- The test doesn't test too much. What it does is just: 
          `yield return new EnterPlayMode();
            Assert.IsTrue(true);
            yield return new ExitPlayMode();`
- We think the failure is caused by HDRP itself in trunk on Mac.


**JIRA ticket:**
https://jira.unity3d.com/browse/ABC-313

**Description of feature/change:**
The test job definition is still there. I just disabled it in the virtual job "test_trigger_hdrp" which is run by nightly trigger.