### PR TITLE
Disable hdrp test in trunk on Mac for release/2.2

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -231,6 +231,13 @@ test_trigger_hdrp:
     - .yamato/upm-ci.yml#pack
     {% for editor in editors %}
     {% for platform in platforms %}
+    {%- comment -%}
+    # Disable hdrp test in trunk on Mac for now which fails nightly trigger because: 
+    # First the test doesn't test too much. Second, we believe the failure is caused by HDRP in trunk
+    {%- endcomment -%}
+    {%- if editor.version == 'trunk' and platform.name == 'mac' -%}
+    {%- continue -%}
+    {%- endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}


### PR DESCRIPTION
**Purpose of this change:**
This is an integration of https://github.com/Unity-Technologies/com.unity.formats.alembic/pull/503 into release/2.2 branch since HDRP test also fails in trunk on Mac there.
The failure is because of the following warning message:
`warning: Assertion failed on expression: 'localPagePos <= page.allocatedSize'
`
We think we can just disable hdrp test in trunk on Mac for now based on:
- The test doesn't test too much. What it does is just:
`yield return new EnterPlayMode(); Assert.IsTrue(true); yield return new ExitPlayMode();
`
- We think the failure is caused by HDRP itself in trunk on Mac.

**JIRA ticket#:** ABC-313 Alembic HDPR tests begin to fail in trunk on Mac (Disable it for now)

**Description of feature/change:**
The test job definition is still there. I just disabled it in the virtual job "test_trigger_hdrp" which is run by nightly trigger.