### PR TITLE
upm-ci can now run tests on centos using only CPU

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -13,10 +13,6 @@ platforms:
     type: Unity::VM::osx
     image: package-ci/mac:stable
     flavor: m1.mac
-#  - name: centOS
-#    type: Unity::VM::GPU
-#    image: package-ci/centos:latest
-#    flavor: b1.large
   - name: ubuntu
     type: Unity::VM
     image: package-ci/ubuntu-20:stable
@@ -43,8 +39,8 @@ bizarro_standalone_platforms:
     flavor: m1.mac
     runtime: standalone
   - name: centOS
-    type: Unity::VM::GPU
-    image: package-ci/centos:latest
+    type: Unity::VM
+    image: package-ci/centos:v1
     flavor: b1.large
     runtime: standalone
   - name: ubuntu
@@ -91,7 +87,7 @@ build_centOS:
   name: Build CentOS
   agent:
     type: Unity::VM
-    image: package-ci/centos:latest
+    image: package-ci/centos:v1
     flavor: b1.large
   commands:
     -  git submodule update --init --recursive 
@@ -134,8 +130,8 @@ test_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-     #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
-     - {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic
+     #- upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
+     - upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic
   artifacts:
     logs.zip:
       paths:
@@ -160,8 +156,8 @@ testProject_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-     #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci project test  --project-path TestProjects/AlembicRecorder --type project-tests --unity-version {{ editor.version }} --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
-     - {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci project test  --project-path TestProjects/AlembicRecorder --type project-tests --unity-version {{ editor.version }}
+     #- upm-ci project test  --project-path TestProjects/AlembicRecorder --type project-tests --unity-version {{ editor.version }} --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
+     - upm-ci project test  --project-path TestProjects/AlembicRecorder --type project-tests --unity-version {{ editor.version }}
   artifacts:
     logs.zip:
       paths:
@@ -186,7 +182,7 @@ testStandalone_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-     - {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %}  upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version {{ editor.version }} --platform {{ platform.runtime }}
+     - upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version {{ editor.version }} --platform {{ platform.runtime }}
   artifacts:
     logs.zip:
       paths:
@@ -211,8 +207,8 @@ testProject_hdrp_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-     #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci project test  --project-path TestProjects/AlembicHDRP --type project-tests --unity-version {{ editor.version }} --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
-     - {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci project test  --project-path TestProjects/AlembicHDRP --type project-tests --unity-version {{ editor.version }}
+     #- upm-ci project test  --project-path TestProjects/AlembicHDRP --type project-tests --unity-version {{ editor.version }} --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'
+     - upm-ci project test  --project-path TestProjects/AlembicHDRP --type project-tests --unity-version {{ editor.version }}
   artifacts:
     logs.zip:
       paths:
@@ -312,7 +308,7 @@ testBizarroStandalone_{{ platform.name }}:
     flavor: {{ platform.flavor}}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-     - {% if platform.name == 'centOS' platform.name == 'stadia' %} DISPLAY=:0 {% endif %}  upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version 2021.1 --platform {{ platform.runtime }}
+     - upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version 2021.1 --platform {{ platform.runtime }}
   artifacts:
     logs.zip:
       paths:


### PR DESCRIPTION
Similar to the change in [upm-ci-yamato-temaplates][1], there's no GPU requirement for running centos tests.

[1]: https://github.cds.internal.unity3d.com/unity/upm-ci-yamato-templates/pull/31