### PR TITLE
Fix CI failure on CentOS because of upm-ci update

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -339,6 +339,8 @@ testBizarroStandalone_{{ platform.name }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+  variables:
+     UPMCI_ACK_DEPRECATED_PYTHON_UNITY_DOWNLOADER: 1
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
      - {% if platform.name == 'centOS' platform.name == 'stadia' %} DISPLAY=:0 {% endif %}  upm-ci project test  --project-path TestProjects/AlembicStandaloneBuild --type project-tests --unity-version 2021.1 --platform {{ platform.runtime }}


### PR DESCRIPTION
**Purpose of this PR:**
CI job fails on Cent OS because of upm-ci update with this change: `Deprecated downloading unity-downloader-cli on the fly and making it a hard dependency. `
But currently `package-ci/centos` images don't have `unity-downloader-cli` pre-installed. This is a problem and will be fixed by [PETS-1006](https://jira.unity3d.com/browse/PETS-1006):`Preinstall Unity Downloader on package-ci/centos`.

Before centos images can have `unity-downloader-cli` pre-installed. We can use a workaround to make CI green which is setting environment variable `UPMCI_ACK_DEPRECATED_PYTHON_UNITY_DOWNLOADER=1` to restore the previous behavior of upm-ci.

**JIRA ticket:**
[ABC-320](https://jira.unity3d.com/browse/ABC-320): CI: Job fails on CentOS because of upm-ci update.