### PR TITLE
Enable APV clean console test in Alembic CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -7,7 +7,9 @@ editors:
 platforms:
   - name: win
     type: Unity::VM
-    image: package-ci/win10:stable
+    # win10:stable fails clean console test in trunk because of warning: Unity is running with Administrator privileges, which is not supported.
+    # Use win10:v2.0.1 which has UAC enabled to workaround that.
+    image: package-ci/win10:v2.0.1
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -160,6 +160,8 @@ test_{{ platform.name }}_{{ editor.version }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
      #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'


### PR DESCRIPTION
## Purpose of this PR:
Enable APV clean console test in Alembic CI

## Ticket/Jira:
[ABC-314](https://jira.unity3d.com/browse/ABC-314): Enable APV clean console test for Alembic package

**List of changes:**
- Set variable "UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST = 1" to package test
- Change Win 10 image to win10:v2.0.1 for package test so that clean console test will not fail in trunk because of this error: `Logs: Unity is running with Administrator privileges, which is not supported.`