### PR TITLE
Re-enable HDPR tests on Mac for Alembic

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -268,13 +268,6 @@ test_trigger_hdrp:
     - .yamato/upm-ci.yml#pack
     {% for editor in editors %}
     {% for platform in platforms %}
-    {%- comment -%}
-    # Disable hdrp test in trunk on Mac for now which fails nightly trigger because: 
-    # First the test doesn't test too much. Second, we belive the failure is caused by HDRP in trunk
-    {%- endcomment -%}
-    {%- if editor.version == 'trunk' and platform.name == 'mac' -%}
-    {%- continue -%}
-    {%- endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Purpose of the PR:
HDPR tests on Mac was disabled for Alembic because of the following warning:
`[07:11:22.763 Information] warning: Assertion failed on expression: 'localPagePos <= page.allocatedSize'`

The warning is a HDPR issue which has been fixed recently by HDPR team.
Since the warning has been fixed, we should re-enable HDPR tests on Mac for Alembic.

## JIRA ticket id:
[ABC-323](https://jira.unity3d.com/browse/ABC-323) CI: Re-enable HDPR tests on Mac for Alembic