### PR TITLE
Re-enable HDRP tests on Mac for release/2.2 branch

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -233,13 +233,6 @@ test_trigger_hdrp:
     - .yamato/upm-ci.yml#pack
     {% for editor in editors %}
     {% for platform in platforms %}
-    {%- comment -%}
-    # Disable hdrp test in trunk on Mac for now which fails nightly trigger because: 
-    # First the test doesn't test too much. Second, we believe the failure is caused by HDRP in trunk
-    {%- endcomment -%}
-    {%- if editor.version == 'trunk' and platform.name == 'mac' -%}
-    {%- continue -%}
-    {%- endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Purpose pf PR:
This is an integration PR of [pull/511](https://github.com/Unity-Technologies/com.unity.formats.alembic/pull/511) into release/2.2 branch which is to re-enable HDPR tests on Mac for Alembic pacakge.

## Jira ticket:
[ABC-323](https://jira.unity3d.com/browse/ABC-323) CI: Re-enable HDPR tests on Mac for Alembic