### PR TITLE
ABC-325: Add support for 2022.2 in Alembic CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -2,6 +2,7 @@ editors:
   - version: 2019.4
   - version: 2020.2
   - version: 2021.1
+  - version: 2022.2
   - version: trunk
 
 platforms:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -269,6 +269,13 @@ test_trigger_hdrp:
     - .yamato/upm-ci.yml#pack
     {% for editor in editors %}
     {% for platform in platforms %}
+    {%- comment -%}
+    # Disable hdrp test for 2022.2 on Mac because of '[Assert] Assertion failed on expression: 'localPagePos <= page.allocatedSize''
+    # This is an HDRP issue and has been fixed in trunk, but apprantly not fixed in 2022.2
+    {%- endcomment -%}
+    {%- if editor.version == '2022.2' and platform.name == 'mac' -%}
+    {%- continue -%}
+    {%- endif -%}
     - .yamato/upm-ci.yml#testProject_hdrp_{{platform.name}}_{{editor.version}}
     {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Purpose of PR:
Add 2022.2 to Alembic CI considering it is the latest release version. Trunk is 2023.1 now.

## JIRA ticket:
[ABC-325](https://jira.unity3d.com/browse/ABC-325) CI: Add support for 2022.2 in Alembic