### PR TITLE
ABC-327 CI: Fix broken CI for Alembic in editor 2020.2

### DIFF
--- a/TestProjects/AlembicRecorder/Packages/manifest.json
+++ b/TestProjects/AlembicRecorder/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.rider": "1.1.4",
     "com.unity.recorder": "3.0.0-pre.2",
     "com.unity.test-framework": "1.1.20",
+    "com.unity.ext.nunit": "1.0.6",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",


### PR DESCRIPTION
## Purpose of this PR:
Fix CI failures in 2020.2 for AlembicRecorder test project. The failure is caused by mismatch between com.unity.ext.nunit@2.0.3 and com.unity.test-framework@1.1.22. Editor 2020.2 is capped at com.unity.test-framework@1.1.22 and com.unity.ext.nunit@1.0.6. 
Don't why suddenly 2020.2 pulls com.unity.ext.nunit@2.0.3 for com.unity.test-framework@1.1.22.
The solution is explicitly setting com.unity.ext.nunit@1.0.6 in project manifest.json.

**JIRA ticket:**
[ABC-327](https://jira.unity3d.com/browse/ABC-327) CI: Fix broken CI for Alembic in editor 2020.2

