### PR TITLE
ABC-330 Fix Alembic clean console tests

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,5 +1,5 @@
 test_editors:
-  - version: 2019.4
+  - version: 2020.3
 
 test_platforms:
   - name: win

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,5 +1,5 @@
 test_editors:
-  - version: 2020.3
+  - version: 2019.4
 
 test_platforms:
   - name: win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,4 +1,5 @@
 editors:
+  - version: 2019.4
   - version: 2020.3
   - version: 2021.3
   - version: 2022.2
@@ -160,8 +161,11 @@ test_{{ platform.name }}_{{ editor.version }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+# Exclude 2019.4 from clean console test because of a known warning in console
+{% if editor.version == '2019.4' %}
   variables:
     UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
+{% endif %}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
      #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,6 @@
 editors:
   - version: 2020.3
-  - version: 2021.1
+  - version: 2021.3
   - version: 2022.2
   - version: trunk
 
@@ -24,14 +24,12 @@ platforms:
     image: package-ci/ubuntu-20:stable
     flavor: b1.large
 
-
-
 standalone_platforms:
   - name: win
+    type: Unity::VM
     image: package-ci/win10:stable
     flavor: b1.large
     runtime: standalone
-    type: Unity::VM
   - name: mac
     type: Unity::VM::osx
     image: package-ci/mac:stable

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,6 +1,5 @@
 editors:
-  - version: 2019.4
-  - version: 2020.2
+  - version: 2020.3
   - version: 2021.1
   - version: 2022.2
   - version: trunk
@@ -310,7 +309,7 @@ api_scrape_check_osx:
     flavor: m1.mac
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
-    - unity-downloader-cli -u 2019.4 -c Editor
+    - unity-downloader-cli -u editors.first.version -c Editor
     - utr/utr --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
   dependencies:
     - .yamato/upm-ci.yml#pack       
@@ -327,7 +326,7 @@ api_scrape_check_win:
     flavor: b1.large
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
-    - unity-downloader-cli -u 2019.4 -c Editor
+    - unity-downloader-cli -u editors.first.version -c Editor
     - utr/utr.bat --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
   dependencies:
     - .yamato/upm-ci.yml#pack         

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -307,7 +307,7 @@ api_scrape_check_osx:
     flavor: m1.mac
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
-    - unity-downloader-cli -u editors.first.version -c Editor
+    - unity-downloader-cli -u {{ editors.first.version }} -c Editor
     - utr/utr --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
   dependencies:
     - .yamato/upm-ci.yml#pack       
@@ -324,7 +324,7 @@ api_scrape_check_win:
     flavor: b1.large
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
-    - unity-downloader-cli -u editors.first.version -c Editor
+    - unity-downloader-cli -u {{ editors.first.version }} -c Editor
     - utr/utr.bat --suite=editor --editor-location=.Editor --testproject=TestProjects/APITests --artifacts_path=artifacts --reruncount=0
   dependencies:
     - .yamato/upm-ci.yml#pack         

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -162,7 +162,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
 # Exclude 2019.4 from clean console test because of a known warning in console
-{% if editor.version == '2019.4' %}
+{% if editor.version != '2019.4' %}
   variables:
     UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
 {% endif %}

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2022-12-06
+### Added
+### Changed
+### Fixed
+
 ## [2.3.0] - 2022-01-28
 ### Added
 ### Changed

--- a/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Util;

--- a/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
@@ -65,7 +65,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         [SetUp]
         public new void SetUp()
         {
-            var cam = Object.FindObjectOfType<Camera>();
+            var cam = Object.FindFirstObjectByType<Camera>();
             camParams.ToCamera(cam);
         }
 

--- a/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/CameraPhysicalParamsTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Formats.Alembic.Util;
 using UnityEngine.TestTools;
-using Object = UnityEngine.Object;
 
 namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 {
@@ -65,7 +64,7 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         [SetUp]
         public new void SetUp()
         {
-            var cam = Object.FindFirstObjectByType<Camera>();
+            var cam = Camera.allCameras.First();
             camParams.ToCamera(cam);
         }
 

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -16,5 +16,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2019.4",
-  "version": "2.3.0"
+  "version": "2.3.1"
 }


### PR DESCRIPTION
## Purpose of this PR:
Fix clean console failures for Alembic CI

**JIRA ticket:**
[ABC-330](https://jira.unity3d.com/browse/ABC-330) Fix Alembic clean console tests

**List of changes:**
- Update 2020.2 to 2020.3 in CI
- Update 2021.1 to 2021.3 in CI
- Exclude 2019.4 from clean console test because of a warning in console
- Replace obsolete API `Object.FindObjectOfType<Camera>()` by using `Camera.allCameras.First()` which will work for all versions
- Bump Alembic version to `2.3.1` and add an entry in CHANGELOG accordingly