### PR TITLE
ABC-330 Remove trunk from release 2.2 branch and exclude 2019.4 from clean console test

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,8 +1,7 @@
 editors:
   - version: 2019.4
-  - version: 2020.2
-  - version: 2021.1
-  - version: trunk
+  - version: 2020.3
+  - version: 2021.3
 
 platforms:
   - name: win
@@ -127,8 +126,11 @@ test_{{ platform.name }}_{{ editor.version }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+# Exclude 2019.4 from clean console test because of a known warning in console
+{% if editor.version != '2019.4' %}
   variables:
     UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
+{% endif %}
   commands:
      - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
      #- {% if platform.name == 'centOS' %} DISPLAY=:0 {% endif %} upm-ci package test --unity-version {{ editor.version }} --package-path com.unity.formats.alembic --enable-code-coverage --code-coverage-options 'enableCyclomaticComplexity;generateHtmlReport'


### PR DESCRIPTION
## Purpose of PR:
Remove trunk from release 2.2 branch because trunk only supports alembic version 2.3.0+.
Also exclude 2019.4 from clean console test because there some logs/warnings in 2019.4, but we don't officially support 2019.4 any more.
Also updated 2020.2 to 2020.3, 2021.1 to 2021.3 in CI.

**JIRA ticket #:**
[ABC-330](https://jira.unity3d.com/browse/ABC-330) Fix Alembic clean console tests