### PR TITLE
Fix reimport on quality change (ABC-336)

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.1] - 2022-12-06
 ### Added
 ### Changed
+- The Editor will stop re-importing Alembic assets when a user changes their project quality settings (HDRP).
 ### Fixed
 
 ## [2.3.0] - 2022-01-28

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.1] - 2022-12-06
 ### Added
 ### Changed
-- The Editor will stop re-importing Alembic assets when a user changes their project quality settings (HDRP).
 ### Fixed
+- When a user changes HDRP quality settings, the Editor no longer re-imports Alembic assets.
 
 ## [2.3.0] - 2022-01-28
 ### Added

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -365,6 +365,12 @@ namespace UnityEditor.Formats.Alembic.Importer
         static readonly TimeSpan checkDependencyFrequency = TimeSpan.FromSeconds(5);
         static DateTime lastCheck;
 
+        /// <summary>
+        /// Generates a hash based on the default material returned by the active render pipeline.
+        /// In the case of HDRP and URP, default material is always the same,
+        /// regardless of the active render pipeline asset.
+        /// </summary>
+        /// <returns></returns>
         static ulong ComputeHash()
         {
             var newPipelineHash = 0UL;
@@ -385,6 +391,11 @@ namespace UnityEditor.Formats.Alembic.Importer
             return newPipelineHash;
         }
 
+        /// <summary>
+        /// Sets dirty the custom dependencies when necessary.
+        /// If the render pipeline's default material has changed, the <see cref="AssetDatabase"/> will
+        /// reimport all Alembic assets.
+        /// </summary>
         static void DirtyCustomDependencies()
         {
             var now = DateTime.Now;

--- a/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
+++ b/com.unity.formats.alembic/Editor/Importer/AlembicImporter.cs
@@ -374,7 +374,7 @@ namespace UnityEditor.Formats.Alembic.Importer
             }
             else
             {
-                if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GraphicsSettings.currentRenderPipeline, out var guid,
+                if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(GraphicsSettings.currentRenderPipeline.defaultMaterial, out var guid,
                     out long fileId))
                 {
                     newPipelineHash =


### PR DESCRIPTION
JIRA TICKET: https://jira.unity3d.com/browse/ABC-336

Bug:

With HDRP, switching the project quality setting results in a reimport of all Alembic assets.
The reason being that our `AlembicImporter` uses the `currentRenderPipeline` asset to build a dependency hash. In HDRP, by default, each quality level has a specific `RenderPipelineAsset` attached to it so every time we switch between quality level, hash is different. 

This mechanism exists so each imported asset always gets a valid default material.

Solution:
Rely on the default material asset instead of the render pipeline asset. It's unlikely that the default material would change often in the lifetime of a project but in case a team uses their own render pipeline, the imported Alembic will still get a proper material.


Tests:
Manual tests, with HDRP and URP projects.
Steps:
* Switch between Quality level in a project with HDRP.

Doc:
- [x] Changelog
- Does not affect the UI