### PR TITLE
Update README.md with official support links

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-# Reporting an issue
-
-If you are willing to report a bug, Unity strongly recommends you to:
-
-- Attach the `.abc` file that can reproduce the issue.
-
-- Indicate which version of the package you are using (for example, 0.1.0-preview).
-
-- Attach the `Editor.log` file (see [Log Files](https://docs.unity3d.com/Manual/LogFiles.html) in the Unity Manual for more details).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ We appreciate all the help we can get to improve the Alembic for Unity package. 
 
 ![example](Screenshots/alembic_example.gif)
 
-## Reporting an issue
+## Support
 
-See the Alembic for Unity's team [recommendations](ISSUE_TEMPLATE.md) about the information you should ideally provide if you want to report an issue.
+For all questions or issues, please post on the [official Unity Forum](https://forum.unity.com/forums/virtual-production.466/) or directly inside the Unity editor using the [Bug Reporter tool](https://unity.com/releases/editor/qa/bug-reporting).

--- a/README.md
+++ b/README.md
@@ -57,4 +57,6 @@ We appreciate all the help we can get to improve the Alembic for Unity package. 
 
 ## Support
 
-For all questions or issues, please post on the [official Unity Forum](https://forum.unity.com/forums/virtual-production.466/) or directly inside the Unity editor using the [Bug Reporter tool](https://unity.com/releases/editor/qa/bug-reporting).
+If you are experiencing a bug while using the Alembic package, please report it directly inside the Unity editor using the [Bug Reporter tool](https://unity.com/releases/editor/qa/bug-reporting).
+
+For any other questions or issues, please post on the [official Unity Forum](https://forum.unity.com/forums/virtual-production.466/).


### PR DESCRIPTION
We have decided to remove the `Github Issues` section of this repository in order to funnel support requests to the proper channels.

This PR updates the README.md page to reflect this decision and include the necessary support information.

I also deleted `ISSUE_TEMPLATE.md` since it specifically contains information on how to submit a github issue but let me know if we should still keep it (just empty?)