### PR TITLE
ABC-369 CI: Jobs fail in trunk because of Script Compilation Problem with com.unity.package-validation-suite package

### DIFF
--- a/TestProjects/AlembicHDRP/Packages/manifest.json
+++ b/TestProjects/AlembicHDRP/Packages/manifest.json
@@ -6,7 +6,6 @@
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.0",
     "com.unity.ide.vscode": "1.2.3",
-    "com.unity.package-validation-suite": "0.4.0-preview.12",
     "com.unity.render-pipelines.high-definition": "7.3.1",
     "com.unity.test-framework": "1.1.18",
     "com.unity.timeline": "1.2.6",

--- a/TestProjects/AlembicImporter/Packages/manifest.json
+++ b/TestProjects/AlembicImporter/Packages/manifest.json
@@ -13,7 +13,6 @@
     "com.unity.package-manager-doctools":"1.6.1-preview",
     "com.unity.formats.alembic": "file:../../../com.unity.formats.alembic",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.package-validation-suite": "0.4.0-preview.12",
     "com.unity.test-framework": "1.1.13",
     "com.unity.timeline": "1.2.6",
     "com.unity.modules.ai": "1.0.0",

--- a/TestProjects/AlembicStandaloneBuild/Packages/manifest.json
+++ b/TestProjects/AlembicStandaloneBuild/Packages/manifest.json
@@ -2,7 +2,6 @@
   "dependencies": {
     "com.unity.formats.alembic": "file:../../../com.unity.formats.alembic",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.package-validation-suite": "0.4.0-preview.12",
     "com.unity.test-framework": "1.1.16",
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",


### PR DESCRIPTION
## Purpose of this PR:
Jobs fail in trunk because of Script Compilation Problem with `com.unity.package-validation-suite@0.4.0-preview.12` package. 
But actually `com.unity.package-validation-suite` package is not needed for project tests. It is for package tests.
Just remove it from project dependencies.

**JIRA ticket:**
[ABC-369](https://jira.unity3d.com/browse/ABC-369)
CI: Jobs fail in trunk because of Script Compilation Problem with com.unity.package-validation-suite package