### PR TITLE
ABC-374: Update bokken images for Alembic CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -8,13 +8,11 @@ editors:
 platforms:
   - name: win
     type: Unity::VM
-    # win10:stable fails clean console test in trunk because of warning: Unity is running with Administrator privileges, which is not supported.
-    # Use win10:v2.0.1 which has UAC enabled to workaround that.
-    image: package-ci/win10:v2.0.1
+    image: package-ci/win10:v4
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: m1.mac
 #  - name: centOS
 #    type: Unity::VM::GPU
@@ -22,25 +20,25 @@ platforms:
 #    flavor: b1.large
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu-20:stable
+    image: package-ci/ubuntu-20.04:v4
     flavor: b1.large
 
 standalone_platforms:
   - name: win
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
     runtime: standalone
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: m1.mac
     runtime: standalone
 
 bizarro_standalone_platforms:
   - name: mac_m2
     type: Unity::metal::devkit
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: m1.mac
     runtime: standalone
   - name: centOS
@@ -50,7 +48,7 @@ bizarro_standalone_platforms:
     runtime: standalone
   - name: ubuntu
     type: Unity::VM::GPU
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-18.04:v4
     flavor: b1.large
     runtime: standalone
   #- name: stadia
@@ -64,7 +62,7 @@ docs-validate:
   name: API docs validation
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-18.04:v4
     flavor: b1.large
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
@@ -92,7 +90,7 @@ build_win:
   name: Build Win
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   commands:
     - git submodule update --init --recursive
@@ -106,7 +104,7 @@ build_mac:
   name: Build Mac
   agent:
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: m1.mac
   commands:
     - git submodule update --init --recursive
@@ -135,7 +133,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm 
@@ -324,7 +322,7 @@ api_scrape_check_win:
   name : Check API Scrape on Win
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
   commands:
     - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
@@ -390,7 +388,7 @@ publish_dry_run:
   name: PublishDryRun
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
     name: Runner
   variables:
@@ -419,7 +417,7 @@ publish:
   name: Publish
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.large
     name: Runner
   variables:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -107,6 +107,7 @@ build_mac:
     image: package-ci/macos-12:v4
     flavor: m1.mac
   commands:
+    - brew install cmake
     - git submodule update --init --recursive
     - ./build.sh
   artifacts:

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+## Any subsequent(*) commands which fail will cause the shell script to exit immediately, otherwise the job will fail silently.
+set -e
+
 # Produce fast and small code (but not debuggable), and produce it to be
 # relocatable since in the end we'll link it all together in a shared object.
 # Note that cmake seems to clobber the -O3 with a -O2, but we can dream.


### PR DESCRIPTION
## Purpose of this PR:
Currently bokken images in Alembic CI are deprecated. Need to replace them with new ones.
Also trunk has crash issues with running in player mode on mac:stable (macos 10.15), because of this, we also need to update Mac image to macos-12.

In this PR, I also added `set -e` in build.sh so that the build script won't fail silently.

**JIRA ticket:**
[ABC-374](https://jira.unity3d.com/browse/ABC-374) CI: Update bokken images for Alembic CI