### PR TITLE
Remove needs for specific versions of VisualStudios from CMD scripts (ABC-385)

### DIFF
--- a/External/build.cmd
+++ b/External/build.cmd
@@ -21,8 +21,7 @@ cmake ..\OpenExr\IlmBase -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH=%installdir% ^
     -DNAMESPACE_VERSIONING=OFF ^
     -DBUILD_SHARED_LIBS=OFF ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 15 2017 Win64"
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target install --config Release
 cd ..
 
@@ -39,7 +38,6 @@ cmake ..\alembic -DCMAKE_BUILD_TYPE=Release ^
     -DALEMBIC_SHARED_LIBS=OFF ^
     -DALEMBIC_ILMBASE_LINK_STATIC=ON ^
     -DILMBASE_ROOT=%installdir% ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 15 2017 Win64"
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target install --config Release
 cd ..

--- a/External/buildDebug.cmd
+++ b/External/buildDebug.cmd
@@ -20,8 +20,7 @@ cmake ..\OpenExr\IlmBase -DCMAKE_BUILD_TYPE=Debug ^
     -DCMAKE_PREFIX_PATH=%installdir% ^
     -DNAMESPACE_VERSIONING=OFF ^
     -DBUILD_SHARED_LIBS=OFF ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 16 2019" -A x64
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target install --config Debug 
 cd ..
 
@@ -38,7 +37,6 @@ cmake ..\alembic -DCMAKE_BUILD_TYPE=Debug ^
     -DALEMBIC_SHARED_LIBS=OFF ^
     -DALEMBIC_ILMBASE_LINK_STATIC=ON ^
     -DILMBASE_ROOT=%installdir% ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 16 2019" -A x64
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target install --config Debug
 cd ..

--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Release ^
     -DENABLE_DEPLOY=OFF ^
     -DCMAKE_PREFIX_PATH=%depsdir% ^
     -DCMAKE_INSTALL_PREFIX=%installdir% ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 15 2017 Win64"
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target INSTALL --config Release
 cd ..

--- a/buildDebug.cmd
+++ b/buildDebug.cmd
@@ -19,7 +19,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug ^
     -DENABLE_DEPLOY=OFF ^
     -DCMAKE_PREFIX_PATH=%depsdir% ^
     -DCMAKE_INSTALL_PREFIX=%installdir% ^
-    -DCMAKE_CXX_FLAGS="/MP" ^
-    -G "Visual Studio 16 2019" -A x64
+    -DCMAKE_CXX_FLAGS="/MP"
 cmake --build . --target INSTALL --config Debug
 cd ..


### PR DESCRIPTION
# Purpose of this PR:

Jira: ABC-385

Remove the need to use specific version of Visual Studios in build scripts. CMake is able to pull whatever version is currently installed on the machine. Devs won't need to update these scripts anymore to build locally with different versions of VS.

# Testing

- [x] CI tests.