### PR TITLE
ABC-386 Set MACOSX_DEPLOYMENT_TARGET to 10.14

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -13,7 +13,7 @@ platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-12:v4
+    image: package-ci/mac:stable
     flavor: m1.mac
 #  - name: centOS
 #    type: Unity::VM::GPU

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -13,7 +13,7 @@ platforms:
     flavor: b1.large
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: m1.mac
 #  - name: centOS
 #    type: Unity::VM::GPU

--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,11 @@ set -e
 export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
 
-OSX_DEPLOYMENT_TARGET=
+OSX_DEPL_TARGET=
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
-   OSX_DEPLOYMENT_TARGET=10.14
+   OSX_DEPL_TARGET=10.14
 
 fi
 
@@ -37,7 +37,7 @@ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DENABLE_DEPLOY=OFF \
     -DCMAKE_PREFIX_PATH=${depsdir} \
     -DCMAKE_INSTALL_PREFIX=${installdir} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPLOYMENT_TARGET}
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPL_TARGET}
 
 cmake --build . --target install --config RelWithDebInfo
 popd

--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,11 @@ set -e
 export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
 
-OSX_DEPLOYMENT_TARGET=""
+OSX_DEPLOYMENT_TARGET=
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
-   OSX_DEPLOYMENT_TARGET="10.14"
+   OSX_DEPLOYMENT_TARGET=10.14
 
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,11 @@ set -e
 export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
 
+OSX_DEPLOYMENT_TARGET=""
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
+   OSX_DEPLOYMENT_TARGET="10.14"
 
 fi
 
@@ -34,6 +36,8 @@ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DUSE_STATIC=ON \
     -DENABLE_DEPLOY=OFF \
     -DCMAKE_PREFIX_PATH=${depsdir} \
-    -DCMAKE_INSTALL_PREFIX=${installdir}
+    -DCMAKE_INSTALL_PREFIX=${installdir} \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPLOYMENT_TARGET}
+
 cmake --build . --target install --config RelWithDebInfo
 popd

--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,10 @@ set -e
 export CXXFLAGS="-O3 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O3 -fomit-frame-pointer -fPIC"
 
-OSX_DEPL_TARGET=
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
-   OSX_DEPL_TARGET=10.14
+   export MACOSX_DEPLOYMENT_TARGET=10.14
 
 fi
 
@@ -36,8 +35,7 @@ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DUSE_STATIC=ON \
     -DENABLE_DEPLOY=OFF \
     -DCMAKE_PREFIX_PATH=${depsdir} \
-    -DCMAKE_INSTALL_PREFIX=${installdir} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPL_TARGET}
+    -DCMAKE_INSTALL_PREFIX=${installdir}
 
 cmake --build . --target install --config RelWithDebInfo
 popd

--- a/buildDebug.sh
+++ b/buildDebug.sh
@@ -6,11 +6,10 @@
 export CXXFLAGS="-O0 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O0 -fomit-frame-pointer -fPIC"
 
-OSX_DEPLOYMENT_TARGET=""
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
-   OSX_DEPLOYMENT_TARGET="10.14"
+   export MACOSX_DEPLOYMENT_TARGET=10.14
 
 fi
 
@@ -33,8 +32,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug \
     -DUSE_STATIC=ON \
     -DENABLE_DEPLOY=OFF \
     -DCMAKE_PREFIX_PATH=${depsdir} \
-    -DCMAKE_INSTALL_PREFIX=${installdir} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPLOYMENT_TARGET}
+    -DCMAKE_INSTALL_PREFIX=${installdir}
 
 cmake --build . --target install --config Debug
 popd

--- a/buildDebug.sh
+++ b/buildDebug.sh
@@ -6,9 +6,11 @@
 export CXXFLAGS="-O0 -fomit-frame-pointer -fPIC"
 export CFLAGS="-O0 -fomit-frame-pointer -fPIC"
 
+OSX_DEPLOYMENT_TARGET=""
 if [ "$(uname)" == "Darwin" ]; then
    export CXXFLAGS="${CXXFLAGS} -arch x86_64 -arch arm64"
    export CFLAGS="${CFLAGS} -arch x86_64 -arch arm64"
+   OSX_DEPLOYMENT_TARGET="10.14"
 
 fi
 
@@ -31,6 +33,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug \
     -DUSE_STATIC=ON \
     -DENABLE_DEPLOY=OFF \
     -DCMAKE_PREFIX_PATH=${depsdir} \
-    -DCMAKE_INSTALL_PREFIX=${installdir}
+    -DCMAKE_INSTALL_PREFIX=${installdir} \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=${OSX_DEPLOYMENT_TARGET}
+
 cmake --build . --target install --config Debug
 popd


### PR DESCRIPTION
## Purpose of this PR:
In Alembic CI, mac image has been update to macos-12. But that will cause problems in `build on Mac` job because the result libs will not be able to load on Mac 10.14+ and Mac 11 which Unity still supports.
Set MACOSX_DEPLOYMENT_TARGET to 10.14.

I am using environment variable `MACOSX_DEPLOYMENT_TARGET`, because:
- If `CMAKE_OSX_DEPLOYMENT_TARGET` is not set explicitly, it will be initialized with `MACOSX_DEPLOYMENT_TARGET`.
- Together with building alembic libs, other dependency libs such as openexr also needs to be built. Using `MACOSX_DEPLOYMENT_TARGET` is the easiest way for all build settings. It will apply to all libs.

I have tested the libs built on Mac 12 with this environment variable `MACOSX_DEPLOYMENT_TARGET` can be loaded on Mac 10.15.

**JIRA ticket:**
[ABC-386](https://jira.unity3d.com/browse/ABC-386) CI: Libs built on macos-12 cannot be loaded on mac 11, need to set CMAKE_OSX_DEPLOYMENT_TARGET to 10.14