### PR TITLE
Fix memory leak with Submeshes (ABC-318)

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Prevent a warning in the Console due to deprecated `RecorderInputSetting.ValidityCheck()` when Alembic is installed along with Recorder.
 - Prevent warnings related to FindObjectOfType<> calls on package installation with Unity Editor 2023.1+.
-- Prevent some memory leak when that results from unloading an Alembic mesh.
+- Prevent some memory leak resulting from Alembic mesh unload.
 
 ### Removed
 - Removed support of Stadia as a build target.

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Prevent a warning in the Console due to deprecated `RecorderInputSetting.ValidityCheck()` when Alembic is installed along with Recorder.
 - Prevent warnings related to FindObjectOfType<> calls on package installation with Unity Editor 2023.1+.
+- Prevent some memory leak when that results from unloading an Alembic mesh.
 
 ### Removed
 - Removed support of Stadia as a build target.

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -121,9 +121,7 @@ namespace UnityEngine.Formats.Alembic.Importer
             m_submeshData.DisposeIfPossible();
             
             foreach (var subMesh in m_submeshes)
-            {
                 subMesh.Dispose();
-            }
             m_submeshes.Clear();
         }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -119,6 +119,12 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             m_splitData.DisposeIfPossible();
             m_submeshData.DisposeIfPossible();
+            
+            foreach (var subMesh in m_submeshes)
+            {
+                subMesh.Dispose();
+            }
+            m_submeshes.Clear();
         }
 
         void UpdateSplits(int numSplits)

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -119,7 +119,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             m_splitData.DisposeIfPossible();
             m_submeshData.DisposeIfPossible();
-            
+
             foreach (var subMesh in m_submeshes)
                 subMesh.Dispose();
             m_submeshes.Clear();


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** https://jira.unity3d.com/browse/ABC-318

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

AlembicMesh holds a list of Submesh instances who own an internal `PinnedList<int>`. These instances don't get diposed on `AlembicMesh.Dispose(bool)` call resulting in a memory leak every time the AlembicMesh is loaded/unloaded.

What remains in memory after we unload a Scene with an animated AlembicMesh:
![image](https://github.com/Unity-Technologies/com.unity.formats.alembic/assets/45040865/d6376a56-f4d2-4dd4-b682-d7f9239e2ccf)

With this fix:
![image](https://github.com/Unity-Technologies/com.unity.formats.alembic/assets/45040865/63abc299-385f-4bb5-895d-896dcffc8d16)

## Testing

**Functional Testing status:** Manually tested.

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->
Manually profiled with a custom player build I've made.
The build could switch between:
- an empty Scene
- a Scene with an animated AlembicMesh.

**Performance Testing status:** N/A

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:** Low
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:** Low
<!-- (Minimal / Low / Medium / High) -->

## Documentation & UX Writing

<!-- Indicate here what kind of review you need from a Technical writer. Feel free to precise what to focus on and give context as needed. -->

| User facing text to review | <!-- Y/N --> | Details |
| :--- | :--- | :--- |
| User interface | N |  |
| Public API docs | N |  |
| Changelog | Y |  |

<!-- Technical writer may update this section, for example to define if yes or no the user manual or any other documentation needs to be updated, and link to a JIRA documentation ticket if the answer is yes. If you don't know, just put a question mark.-->

| Documentation halo effect | <!-- Y/N/? --> | Jira link |
| :--- | :--- | :--- |
| User manual | N |  |
| Other docs | N |  |