### PR TITLE
ABC-403 Exclude 2019.4 from HDRP tests

### DIFF
--- a/.yamato/package-triggers.yml
+++ b/.yamato/package-triggers.yml
@@ -49,7 +49,10 @@ nightly_test_trigger:
 {% endfor %}
 
 {% for editor in test_editors %}
+# Exclude 2019.4 from HDRP tests
+{% if editor.version != "2019.4" %}
 {% for platform in test_platforms %}
     - .yamato/project-test.yml#test_project_{{ hdrp_test_project.name }}_{{ platform.name }}_{{ editor.version }}
 {% endfor %}
+{% endif %}
 {% endfor %}

--- a/.yamato/project-test.yml
+++ b/.yamato/project-test.yml
@@ -66,7 +66,9 @@ test_project_{{ standalone_test_project.name }}_{{ platform.name }}_{{ editor.ve
 
 
 # HDRP test project
+# Exclude 2019.4 from running because of HDRP test project compatinility issue
 {% for editor in test_editors %}
+{% if editor.version != "2019.4" %}
 {% for platform in test_platforms %}
 test_project_{{ hdrp_test_project.name }}_{{ platform.name }}_{{ editor.version }}:
   name : Project test {{ hdrp_test_project.name }} in version {{ editor.version }} on {{ platform.name }}
@@ -84,4 +86,5 @@ test_project_{{ hdrp_test_project.name }}_{{ platform.name }}_{{ editor.version 
   dependencies:
     - .yamato/package-pack.yml#pack
 {% endfor %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
## Purpose of this PR:
We are trying to upgrade AlembicHDRP project to 22.2, but it will be compatible with 2019. Since 2019 is too old and unsupported, we just decide to exclude it from HDRP test.

**JIRA tickets:**
[ABC-403](https://jira.unity3d.com/browse/ABC-403) Upgrade AlembicHDRP project to 22.2