### PR TITLE
Add package field to .buginfo

### DIFF
--- a/.buginfo
+++ b/.buginfo
@@ -2,3 +2,4 @@ system: jira
 server: jira.unity3d.com
 project: ABC
 issuetype: Bug
+package: Alembic Importer


### PR DESCRIPTION
## Purpose of this PR
As part of .buginfo adoption initiative and in accordance with the new rules for .buginfo files, this PR adds the `package` field into the `.buginfo` file. The field value corresponds to the Jira Package Insight object: `Alembic Importer`