### PR TITLE
[ABC-490] Access name and size of attributes from the summary for polymesh 

### DIFF
--- a/Source/abci/Importer/AlembicImporter.h
+++ b/Source/abci/Importer/AlembicImporter.h
@@ -34,7 +34,7 @@ class aiPoints;   // : aiSchema
 class aiProperty;
 struct AttributeData;
 struct AttributeDataToTransfer;
-
+struct AttributeSummary;
 
 enum class NormalsMode
 {
@@ -158,7 +158,7 @@ struct aiMeshSummary
 struct aiMeshSampleSummary
 {
     bool visibility = true;
-
+    AttributeSummary* attributes = nullptr;
     int split_count = 0;
     int submesh_count = 0;
     int vertex_count = 0;

--- a/Source/abci/Importer/aiMeshSchema.h
+++ b/Source/abci/Importer/aiMeshSchema.h
@@ -289,7 +289,7 @@ struct AttributeData
     RawVector<int> remap;
     int size;
     aiPropertyType type1;
-    std::string name;
+    const char* name;
     bool interpolate = false;
     const Alembic::Abc::PropertyHeader& header;
 
@@ -302,6 +302,12 @@ struct AttributeDataToTransfer
     void* data;
     aiPropertyType type;
 };
+
+struct AttributeSummary {
+    const char* name;
+    int size;
+};
+
 
 template<typename T, typename U>
 template<typename Tp>
@@ -324,8 +330,8 @@ void aiMeshSchema<T, U>::readAttribute(aiObject* object, std::vector<AttributeDa
                 AttributeData* attribute = new AttributeData(header);
                 attribute->data = param;
                 attribute->size = sizeof(param);
-                attribute->type1 = aiGetPropertyType(header);  // or store type in string as geomparam for more possibilites
-                attribute->name = header.getName();
+                attribute->type1 = aiGetPropertyType(header);  // or store type in string as geomparam for more possibilites 
+                attribute->name = header.getName().c_str();
                 attributes.push_back(attribute);
             }
         }
@@ -1678,6 +1684,18 @@ void aiMeshSample<T>::getSummary(aiMeshSampleSummary& dst) const
     dst.vertex_count = m_topology->getVertexCount();
     dst.index_count = m_topology->getIndexCount();
     dst.topology_changed = m_topology_changed;
+
+    AttributeSummary* ptrArray = new AttributeSummary[m_attributes_ref.size()];
+
+    for (size_t i = 0; i < m_attributes_ref.size(); i++) {
+        ptrArray[i].size = m_attributes_ref[i]->size;
+        ptrArray[i].name = m_attributes_ref[i]->name;
+    }
+
+    memcpy(dst.attributes, ptrArray, m_attributes_ref.size() * sizeof(AttributeSummary));
+
+    delete[] ptrArray;
+ 
 }
 
 template<typename T>

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AbcAPI.cs
@@ -162,9 +162,17 @@ namespace UnityEngine.Formats.Alembic.Sdk
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    struct aiAttributesSummary
+    {
+       public IntPtr name;
+       public int size;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     internal struct aiMeshSampleSummary
     {
         public Bool visibility { get; set; }
+        public unsafe void* attributes;
 
         public int splitCount { get; set; }
         public int submeshCount { get; set; }

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
@@ -78,6 +79,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         NativeArray<aiSubmeshSummary> m_submeshSummaries;
         NativeArray<aiPolyMeshData> m_splitData;
         NativeArray<aiSubmeshData> m_submeshData;
+        NativeArray<aiAttributesSummary> m_attributesSummary;
 
         JobHandle fillVertexBufferHandle;
         List<Split> m_splits = new List<Split>();
@@ -119,6 +121,8 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             m_splitData.DisposeIfPossible();
             m_submeshData.DisposeIfPossible();
+
+            m_attributesSummary.DisposeIfPossible();
 
             foreach (var subMesh in m_submeshes)
                 subMesh.Dispose();
@@ -178,7 +182,11 @@ namespace UnityEngine.Formats.Alembic.Importer
 
             var sample = m_abcSchema.sample;
 
+            m_attributesSummary.ResizeIfNeeded(m_summary.attributesCount);
+            m_sampleSummary.attributes= m_attributesSummary.GetPointer();
+
             sample.GetSummary(ref m_sampleSummary);
+
             var splitCount = m_sampleSummary.splitCount;
             var submeshCount = m_sampleSummary.submeshCount;
 


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #: [ABC-490](https://jira.unity3d.com/browse/ABC-490)**

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->
This PR allows to access the data (name and size) of the attributes from the summary of polymesh.

## Testing

**Functional Testing status:**
Manual testing: output the data we want to verify in the console after importing an asset. 
The line for Debug.Log is kept in the code for testing purposes. 
<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

