### PR TITLE
[ABC-499] Fix crash when importing corrupted alembic

### DIFF
--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -17,7 +17,6 @@ pack:
     # Require once with exemptions applied (pvp_xray_exemptions.json) to determine job status and report errors
     # If the job fails because of new errors which are NOT exempted by pvp_xray_exemptions.json and thought expected, we can use new_exemptions.json to replace the exemptions in pvp_xray_exemptions.json
     - upm-pvp require "supported rme ./pvp_xray_exemptions.json" --allow-missing --results "upm-ci~/xray"
-    - upm-pvp require "supported rme -PVP-41-1" --allow-missing --results "upm-ci~/xray"
   artifacts:
     packages:
       paths:

--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -16,7 +16,7 @@ pack:
     - upm-pvp require "supported rme" --allow-missing --no-report --results upm-ci~/xray --exemptions "upm-ci~/xray/new_exemptions.json"
     # Require once with exemptions applied (pvp_xray_exemptions.json) to determine job status and report errors
     # If the job fails because of new errors which are NOT exempted by pvp_xray_exemptions.json and thought expected, we can use new_exemptions.json to replace the exemptions in pvp_xray_exemptions.json
-    - upm-pvp require "supported rme ./pvp_xray_exemptions.json" --allow-missing --results "upm-ci~/xray"
+    - upm-pvp require "supported rme -PVP-41-1 ./pvp_xray_exemptions.json" --allow-missing --results "upm-ci~/xray"
   artifacts:
     packages:
       paths:

--- a/.yamato/package-pack.yml
+++ b/.yamato/package-pack.yml
@@ -17,6 +17,7 @@ pack:
     # Require once with exemptions applied (pvp_xray_exemptions.json) to determine job status and report errors
     # If the job fails because of new errors which are NOT exempted by pvp_xray_exemptions.json and thought expected, we can use new_exemptions.json to replace the exemptions in pvp_xray_exemptions.json
     - upm-pvp require "supported rme ./pvp_xray_exemptions.json" --allow-missing --results "upm-ci~/xray"
+    - upm-pvp require "supported rme -PVP-41-1" --allow-missing --results "upm-ci~/xray"
   artifacts:
     packages:
       paths:

--- a/Source/abci/Importer/aiMeshSchema.h
+++ b/Source/abci/Importer/aiMeshSchema.h
@@ -708,13 +708,17 @@ void aiMeshSchema<T, U>::cookSampleBody(U& sample)
         }
         else if (!summary.compute_velocities && summary.has_velocities_prop)
         {
-            auto& dst = summary.constant_velocities ? m_constant_velocities : sample.m_velocities;
-            Remap(dst, *sample.m_velocities_sp, topology.m_remap_points);
-            if (config.swap_handedness)
-                SwapHandedness(dst.data(), (int)dst.size());
-            if (config.scale_factor != 1.0f)
-                ApplyScale(dst.data(), (int)dst.size(), config.scale_factor);
-            sample.m_velocities_ref = dst;
+            // `sample.m_velocities_sp` can be null when `summary.has_points` is false
+            if (sample.m_velocities_sp != nullptr)
+            {
+                auto& dst = summary.constant_velocities ? m_constant_velocities : sample.m_velocities;
+                Remap(dst, *sample.m_velocities_sp, topology.m_remap_points);
+                if (config.swap_handedness)
+                    SwapHandedness(dst.data(), (int)dst.size());
+                if (config.scale_factor != 1.0f)
+                    ApplyScale(dst.data(), (int)dst.size(), config.scale_factor);
+                sample.m_velocities_ref = dst;
+            }
         }
     }
 

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed crash when importing a corrupted Alembic file.
+
 ## [2.4.0] - 2024-03-13
 ### Added
 - Added library for Windows ARM64 platform support.

--- a/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
+++ b/com.unity.formats.alembic/Tests/Editor/EditorTests.cs
@@ -56,6 +56,15 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
             Assert.IsEmpty(inst.GetComponentsInChildren<MeshFilter>().Select(x => x.sharedMesh != null));
         }
 
+        [Test]
+        public void CorruptedAlembicFileIsHandledGracefully()
+        {
+            var path = AssetDatabase.GUIDToAssetPath("0c10a673a92234124a1fc31297198530");
+            AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceSynchronousImport);
+            var asset = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            Assert.IsNotNull(asset);
+        }
+
         [UnityTest]
         public IEnumerator AddCurveRenderingSettingIsObeyed([Values] bool addCurve)
         {

--- a/com.unity.formats.alembic/Tests/Runtime/Data/SlimeMolding.abc.meta
+++ b/com.unity.formats.alembic/Tests/Runtime/Data/SlimeMolding.abc.meta
@@ -1,0 +1,38 @@
+fileFormatVersion: 2
+guid: 0c10a673a92234124a1fc31297198530
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: f53f5fc499d31e44b9deee84d28a9ee8, type: 3}
+  rootGameObjectId: 
+  rootGameObjectName: 
+  importerVersion: 1
+  streamSettings:
+    normals: 1
+    tangents: 1
+    cameraAspectRatio: 2
+    importVisibility: 1
+    scaleFactor: 0.01
+    swapHandedness: 1
+    flipFaces: 0
+    interpolateSamples: 1
+    importPointPolygon: 1
+    importLinePolygon: 1
+    importTrianglePolygon: 1
+    importXform: 1
+    importCameras: 1
+    importMeshes: 1
+    importPoints: 0
+    importCurves: 1
+    createCurveRenderers: 0
+  abcStartTime: 0.041666666666666664
+  abcEndTime: 10.416666666666666
+  startTime: 0.041666666666666664
+  endTime: 10.416666666666666
+  importWarning: 
+  firstImport: 1
+  isHDF5: 0

--- a/pvp_xray_exemptions.json
+++ b/pvp_xray_exemptions.json
@@ -23,11 +23,6 @@
             "UnityEngine.Formats.Alembic.Util.AlembicRecorder: Recording: unexpected <returns>; use <value> instead",
             "UnityEngine.Formats.Alembic.Importer.AlembicStreamPlayer: bool ReloadStream(bool): text or XML content outside a top-level tag"
           ]
-        },
-        "PVP-41-1": {
-          "errors": [
-            "CHANGELOG.md: line 9: Unreleased section is not allowed for public release"
-          ]
         }
       }
     }

--- a/pvp_xray_exemptions.json
+++ b/pvp_xray_exemptions.json
@@ -23,6 +23,11 @@
             "UnityEngine.Formats.Alembic.Util.AlembicRecorder: Recording: unexpected <returns>; use <value> instead",
             "UnityEngine.Formats.Alembic.Importer.AlembicStreamPlayer: bool ReloadStream(bool): text or XML content outside a top-level tag"
           ]
+        },
+        "PVP-41-1": {
+          "errors": [
+            "CHANGELOG.md: line 9: Unreleased section is not allowed for public release"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** ABC-499

Fix crash when importing a corrupted Alembic file.
Due to the fix in ABC-100, there were cases where `summary.haspoints` became `false`, and in such cases, accessing `sample.mvelocities_sp` (which was not set) caused a crash.

## Testing

**Functional Testing status:**
Added unit test: `UnityEditor.Formats.Alembic.Exporter.UnitTests.EditorTests.CorruptedAlembicFileIsHandledGracefully`

**Performance Testing status:**
N/A

## Overall Product Risks

**Complexity:**
Minimal

**Halo Effect:**
Minimal

## Documentation & UX Writing

<!-- Indicate here what kind of review you need from a Technical writer. Feel free to precise what to focus on and give context as needed. -->

| User facing text to review | <!-- Y/N --> | Details |
| :--- | :--- | :--- |
| User interface | N |  |
| Public API docs | N |  |
| Changelog | Y |  |

<!-- Technical writer may update this section, for example to define if yes or no the user manual or any other documentation needs to be updated, and link to a JIRA documentation ticket if the answer is yes. If you don't know, just put a question mark.-->

| Documentation halo effect | <!-- Y/N/? --> | Jira link |
| :--- | :--- | :--- |
| User manual | N |  |
| Other docs | N |  |

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md <!-- Remove if not applicable. -->
