### PR TITLE
 [UUM-137643] Fix compilation errors and warnings

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -1,24 +1,24 @@
 test_editors:
   - version: 2021.3
-  - version: 2022.3
   - version: 6000.0
-  - version: 6000.2
   - version: 6000.3
   - version: 6000.4
+  - version: 6000.5
   - version: trunk
 
 nightly_test_editors:
-  - version: 2022.3
   - version: 6000.0
-  - version: 6000.2
   - version: 6000.3
   - version: 6000.4
-  - version: trunk  
+  - version: 6000.5
+  - version: trunk
 
 clean_console_test_editors:
   - version: 6000.0
-  - version: 6000.2
-  - version: trunk  
+  - version: 6000.3
+  - version: 6000.4
+  - version: 6000.5
+  - version: trunk
 
 promotion_test_editors:
   - version: 2021.3

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.5] - 2026-04-02
+### Changed
+- Update deprecated and obsolete APIs available in Unity 6000.4 and above.
+
 ## [2.4.4] - 2026-01-29
 ### Changed
 - Signed binaries on Windows and Mac.

--- a/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
@@ -43,7 +43,9 @@ namespace UnityEngine.Formats.Alembic.Exporter
             {
                 return settings.TargetBranch != null ? settings.TargetBranch.GetComponentsInChildren<T>() : Enumerable.Empty<T>();
             }
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
+            return Object.FindObjectsByType<T>();
+#elif UNITY_2023_1_OR_NEWER
             return Object.FindObjectsByType<T>(FindObjectsSortMode.InstanceID);
 #else
             return Object.FindObjectsOfType<T>();

--- a/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Analytics/AlembicExporterAnalytics.cs
@@ -44,6 +44,7 @@ namespace UnityEngine.Formats.Alembic.Exporter
                 return settings.TargetBranch != null ? settings.TargetBranch.GetComponentsInChildren<T>() : Enumerable.Empty<T>();
             }
 #if UNITY_6000_4_OR_NEWER
+            // Analytics only counts component instances; order does not affect the result.
             return Object.FindObjectsByType<T>();
 #elif UNITY_2023_1_OR_NEWER
             return Object.FindObjectsByType<T>(FindObjectsSortMode.InstanceID);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -953,7 +953,9 @@ namespace UnityEngine.Formats.Alembic.Util
             if (m_settings.Scope == ExportScope.TargetBranch && TargetBranch != null)
                 return TargetBranch.GetComponentsInChildren(type);
             else
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
+                return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type), e => (Component)e);
+#elif UNITY_2023_1_OR_NEWER
                 return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type, FindObjectsSortMode.InstanceID), e => (Component)e);
 #else
                 return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsOfType(type), e => (Component)e);

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -548,7 +548,7 @@ namespace UnityEngine.Formats.Alembic.Util
                     return;
                 }
 #if UNITY_6000_4_OR_NEWER
-                abcObject = parent.abcObject.NewXform(target.name + " (" + EntityId.ToULong(target.GetEntityId()).ToString("X8") + ")", timeSamplingIndex);
+                abcObject = parent.abcObject.NewXform(target.name + " (" + EntityId.ToULong(target.GetEntityId()).ToString("X16") + ")", timeSamplingIndex);
 #else
                 abcObject = parent.abcObject.NewXform(target.name + " (" + target.GetInstanceID().ToString("X8") + ")", timeSamplingIndex);
 #endif
@@ -965,7 +965,7 @@ namespace UnityEngine.Formats.Alembic.Util
 #if UNITY_6000_4_OR_NEWER
         /// <summary>
         /// Sorts <paramref name="components"/> in place into a stable order derived from each object’s scene and
-        /// transform hierarchy (see <see cref="AppendStableHierarchySortKey"/>).
+        /// transform hierarchy (see <see cref="AppendStableHierarchySortKey(StringBuilder, Component, List{int})"/>).
         /// </summary>
         /// <remarks>
         /// <para>
@@ -976,8 +976,9 @@ namespace UnityEngine.Formats.Alembic.Util
         /// </para>
         /// <para>
         /// Implementation: allocate a parallel <c>string[]</c> of the same length, fill each entry by clearing a shared
-        /// <see cref="StringBuilder"/>, calling <see cref="AppendStableHierarchySortKey(StringBuilder, Component)"/>, and
-        /// assigning <c>keys[i] = sb.ToString()</c>. Then <c>Array.Sort(keys, components, StringComparer.Ordinal)</c>
+        /// <see cref="StringBuilder"/> and a shared <c>List&lt;int&gt;</c> scratchpad, calling
+        /// <see cref="AppendStableHierarchySortKey(StringBuilder, Component, List{int})"/>, and assigning
+        /// <c>keys[i] = sb.ToString()</c>. Then <c>Array.Sort(keys, components, StringComparer.Ordinal)</c>
         /// reorders <paramref name="components"/> to match ascending key order. Arrays of length 0 or 1, or a null
         /// reference, are left unchanged without allocating.
         /// </para>
@@ -989,10 +990,12 @@ namespace UnityEngine.Formats.Alembic.Util
 
             var keys = new string[components.Length];
             var sb = new StringBuilder(128);
+            var scratchpad = new List<int>(8);
             for (int i = 0; i < components.Length; i++)
             {
                 sb.Clear();
-                AppendStableHierarchySortKey(sb, components[i]);
+                scratchpad.Clear();
+                AppendStableHierarchySortKey(sb, components[i], scratchpad);
                 keys[i] = sb.ToString();
             }
 
@@ -1009,32 +1012,28 @@ namespace UnityEngine.Formats.Alembic.Util
         /// and transform hierarchy so export iteration is reproducible.
         /// </para>
         /// <para>
-        /// The key is built as: <c>scene.path</c>, a U+0001 separator, <c>scene.buildIndex</c> formatted as four digits,
-        /// another separator, then the path from scene root to the component’s transform as dot-separated
+        /// The key is built as: <c>scene.path</c>, a U+0001 separator, then the path from scene root to the component’s transform as dot-separated
         /// <see cref="Transform.GetSiblingIndex"/> values, each formatted as eight digits (<c>D8</c>) so lexical
         /// string order matches numeric sibling order. Walking from leaf to root and emitting indices root-first yields
         /// depth-first hierarchy order when keys are compared with <see cref="StringComparer.Ordinal"/>.
         /// </para>
         /// </remarks>
-        internal static void AppendStableHierarchySortKey(StringBuilder sb, Component c)
+        internal static void AppendStableHierarchySortKey(StringBuilder sb, Component c, List<int> scratchpad)
         {
             var scene = c.gameObject.scene;
             sb.Append(scene.path);
             sb.Append('\x1');
-            sb.Append(scene.buildIndex.ToString("D4"));
-            sb.Append('\x1');
             var t = c.transform;
-            var indices = new List<int>(8);
             while (t != null)
             {
-                indices.Add(t.GetSiblingIndex());
+                scratchpad.Add(t.GetSiblingIndex());
                 t = t.parent;
             }
-            for (int i = indices.Count - 1; i >= 0; i--)
+            for (int i = scratchpad.Count - 1; i >= 0; i--)
             {
-                if (i < indices.Count - 1)
+                if (i < scratchpad.Count - 1)
                     sb.Append('.');
-                sb.Append(indices[i].ToString("D8"));
+                sb.Append(scratchpad[i].ToString("D8"));
             }
         }
 #endif

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -964,9 +964,24 @@ namespace UnityEngine.Formats.Alembic.Util
 
 #if UNITY_6000_4_OR_NEWER
         /// <summary>
-        /// Deterministic order for export: loaded scene (path, build index), then hierarchy (sibling indices from root).
-        /// Does not use InstanceID/EntityId ordering (see Unity 6+ engine guidance).
+        /// Sorts <paramref name="components"/> in place into a stable order derived from each object’s scene and
+        /// transform hierarchy (see <see cref="AppendStableHierarchySortKey"/>).
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// On Unity 6.4 and newer, sort mode is deprecated for <c>FindObjectsByType</c>, so the returned array has no
+        /// defined order. Sorting by <c>InstanceID</c> / <c>EntityId</c> is also discouraged. This method reorders the
+        /// array so exporter iteration (for example from <c>GetTargets</c>) is deterministic and aligned with scene and
+        /// hierarchy rather than identity allocation.
+        /// </para>
+        /// <para>
+        /// Implementation: allocate a parallel <c>string[]</c> of the same length, fill each entry by clearing a shared
+        /// <see cref="StringBuilder"/>, calling <see cref="AppendStableHierarchySortKey(StringBuilder, Component)"/>, and
+        /// assigning <c>keys[i] = sb.ToString()</c>. Then <c>Array.Sort(keys, components, StringComparer.Ordinal)</c>
+        /// reorders <paramref name="components"/> to match ascending key order. Arrays of length 0 or 1, or a null
+        /// reference, are left unchanged without allocating.
+        /// </para>
+        /// </remarks>
         internal static void SortComponentsByStableSceneHierarchy(Component[] components)
         {
             if (components == null || components.Length <= 1)
@@ -984,6 +999,23 @@ namespace UnityEngine.Formats.Alembic.Util
             Array.Sort(keys, components, StringComparer.Ordinal);
         }
 
+        /// <summary>
+        /// Appends a deterministic sort key for <paramref name="c"/> to <paramref name="sb"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unity 6.4+ no longer guarantees an ordering for <c>FindObjectsByType</c>, and engine guidance is to avoid
+        /// sorting by <c>InstanceID</c> / <c>EntityId</c>. This key instead fixes a stable order from scene identity
+        /// and transform hierarchy so export iteration is reproducible.
+        /// </para>
+        /// <para>
+        /// The key is built as: <c>scene.path</c>, a U+0001 separator, <c>scene.buildIndex</c> formatted as four digits,
+        /// another separator, then the path from scene root to the component’s transform as dot-separated
+        /// <see cref="Transform.GetSiblingIndex"/> values, each formatted as eight digits (<c>D8</c>) so lexical
+        /// string order matches numeric sibling order. Walking from leaf to root and emitting indices root-first yields
+        /// depth-first hierarchy order when keys are compared with <see cref="StringComparer.Ordinal"/>.
+        /// </para>
+        /// </remarks>
         internal static void AppendStableHierarchySortKey(StringBuilder sb, Component c)
         {
             var scene = c.gameObject.scene;

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -956,13 +956,15 @@ namespace UnityEngine.Formats.Alembic.Util
         {
             if (m_settings.Scope == ExportScope.TargetBranch && TargetBranch != null)
                 return TargetBranch.GetComponentsInChildren(type);
-            else
+
 #if UNITY_6000_4_OR_NEWER
-                return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type), e => (Component)e);
+            var objects = GameObject.FindObjectsByType(type);
+            Array.Sort(objects, (a, b) => EntityId.ToULong(a.GetEntityId()).CompareTo(EntityId.ToULong(b.GetEntityId())));
+            return Array.ConvertAll<UnityEngine.Object, Component>(objects, e => (Component)e);
 #elif UNITY_2023_1_OR_NEWER
-                return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type, FindObjectsSortMode.InstanceID), e => (Component)e);
+            return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type, FindObjectsSortMode.InstanceID), e => (Component)e);
 #else
-                return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsOfType(type), e => (Component)e);
+            return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsOfType(type), e => (Component)e);
 #endif
         }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -839,7 +839,11 @@ namespace UnityEngine.Formats.Alembic.Util
 
         class CaptureNode
         {
+#if UNITY_6000_4_OR_NEWER
+            public ulong entityId;
+#else
             public int instanceID;
+#endif
             public Type componentType;
             public CaptureNode parent;
             public Transform transform;
@@ -877,9 +881,15 @@ namespace UnityEngine.Formats.Alembic.Util
 
         aeContext m_ctx;
         ComponentCapturer m_root;
+#if UNITY_6000_4_OR_NEWER
+        Dictionary<ulong, CaptureNode> m_nodes;
+        List<CaptureNode> m_newNodes;
+        List<ulong> m_entityIdsToRemove;
+#else
         Dictionary<int, CaptureNode> m_nodes;
         List<CaptureNode> m_newNodes;
         List<int> m_iidToRemove;
+#endif
         int m_lastTimeSamplingIndex;
         int m_startFrameOfLastTimeSampling;
 
@@ -1029,11 +1039,20 @@ namespace UnityEngine.Formats.Alembic.Util
             if (node == null) { return null; }
 
 #if UNITY_6000_4_OR_NEWER
-            int iid = (int)EntityId.ToULong(node.gameObject.GetEntityId());
+            ulong entityId = EntityId.ToULong(node.gameObject.GetEntityId());
 #else
             int iid = node.gameObject.GetInstanceID();
 #endif
             CaptureNode cn;
+#if UNITY_6000_4_OR_NEWER
+            if (m_nodes.TryGetValue(entityId, out cn)) { return cn; }
+
+            cn = new CaptureNode();
+            cn.entityId = entityId;
+            cn.transform = node;
+            cn.parent = ConstructTree(node.parent);
+            m_nodes.Add(entityId, cn);
+#else
             if (m_nodes.TryGetValue(iid, out cn)) { return cn; }
 
             cn = new CaptureNode();
@@ -1041,6 +1060,7 @@ namespace UnityEngine.Formats.Alembic.Util
             cn.transform = node;
             cn.parent = ConstructTree(node.parent);
             m_nodes.Add(iid, cn);
+#endif
             m_newNodes.Add(cn);
             return cn;
         }
@@ -1086,9 +1106,15 @@ namespace UnityEngine.Formats.Alembic.Util
             if (parent != null && parent.transformCapturer == null)
             {
                 SetupComponentCapturer(parent);
+#if UNITY_6000_4_OR_NEWER
+                if (!m_nodes.ContainsKey(parent.entityId) || !m_newNodes.Contains(parent))
+                {
+                    m_nodes.Add(parent.entityId, parent);
+#else
                 if (!m_nodes.ContainsKey(parent.instanceID) || !m_newNodes.Contains(parent))
                 {
                     m_nodes.Add(parent.instanceID, parent);
+#endif
                     m_newNodes.Add(parent);
                 }
             }
@@ -1201,9 +1227,15 @@ namespace UnityEngine.Formats.Alembic.Util
             }
 
             m_root = new RootCapturer(this, m_ctx.topObject);
+#if UNITY_6000_4_OR_NEWER
+            m_nodes = new Dictionary<ulong, CaptureNode>();
+            m_newNodes = new List<CaptureNode>();
+            m_entityIdsToRemove = new List<ulong>();
+#else
             m_nodes = new Dictionary<int, CaptureNode>();
             m_newNodes = new List<CaptureNode>();
             m_iidToRemove = new List<int>();
+#endif
             m_lastTimeSamplingIndex = 1;
             m_startFrameOfLastTimeSampling = 0;
 
@@ -1228,7 +1260,11 @@ namespace UnityEngine.Formats.Alembic.Util
         {
             if (!m_recording) { return; }
 
+#if UNITY_6000_4_OR_NEWER
+            m_entityIdsToRemove = null;
+#else
             m_iidToRemove = null;
+#endif
             m_newNodes = null;
             m_nodes = null;
             m_root = null;
@@ -1271,14 +1307,24 @@ namespace UnityEngine.Formats.Alembic.Util
                 var node = kvp.Value;
                 node.Capture();
                 if (node.transform == null)
+#if UNITY_6000_4_OR_NEWER
+                    m_entityIdsToRemove.Add(node.entityId);
+#else
                     m_iidToRemove.Add(node.instanceID);
+#endif
             }
             m_ctx.MarkFrameEnd();
 
             // remove deleted GameObjects
+#if UNITY_6000_4_OR_NEWER
+            foreach (ulong entityId in m_entityIdsToRemove)
+                m_nodes.Remove(entityId);
+            m_entityIdsToRemove.Clear();
+#else
             foreach (int iid in m_iidToRemove)
                 m_nodes.Remove(iid);
             m_iidToRemove.Clear();
+#endif
 
             // advance time
             ++m_frameCount;

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -546,7 +546,11 @@ namespace UnityEngine.Formats.Alembic.Util
                     m_target = null;
                     return;
                 }
+#if UNITY_6000_4_OR_NEWER
+                abcObject = parent.abcObject.NewXform(target.name + " (" + EntityId.ToULong(target.GetEntityId()).ToString("X8") + ")", timeSamplingIndex);
+#else
                 abcObject = parent.abcObject.NewXform(target.name + " (" + target.GetInstanceID().ToString("X8") + ")", timeSamplingIndex);
+#endif
                 m_target = target;
             }
 
@@ -976,7 +980,11 @@ namespace UnityEngine.Formats.Alembic.Util
         {
             if (node == null) { return null; }
 
+#if UNITY_6000_4_OR_NEWER
+            int iid = (int)EntityId.ToULong(node.gameObject.GetEntityId());
+#else
             int iid = node.gameObject.GetInstanceID();
+#endif
             CaptureNode cn;
             if (m_nodes.TryGetValue(iid, out cn)) { return cn; }
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -1033,8 +1033,21 @@ namespace UnityEngine.Formats.Alembic.Util
             {
                 if (i < scratchpad.Count - 1)
                     sb.Append('.');
-                sb.Append(scratchpad[i].ToString("D8"));
+                AppendD8(sb, scratchpad[i]);
             }
+        }
+
+        // Appends value zero-padded to 8 digits directly into sb with no string allocation.
+        static void AppendD8(StringBuilder sb, int value)
+        {
+            sb.Append((char)('0' + value / 10000000 % 10));
+            sb.Append((char)('0' + value / 1000000  % 10));
+            sb.Append((char)('0' + value / 100000   % 10));
+            sb.Append((char)('0' + value / 10000    % 10));
+            sb.Append((char)('0' + value / 1000     % 10));
+            sb.Append((char)('0' + value / 100      % 10));
+            sb.Append((char)('0' + value / 10       % 10));
+            sb.Append((char)('0' + value             % 10));
         }
 #endif
 

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -951,6 +952,50 @@ namespace UnityEngine.Formats.Alembic.Util
 
 #endif
 
+#if UNITY_6000_4_OR_NEWER
+        /// <summary>
+        /// Deterministic order for export: loaded scene (path, build index), then hierarchy (sibling indices from root).
+        /// Does not use InstanceID/EntityId ordering (see Unity 6+ engine guidance).
+        /// </summary>
+        static void SortComponentsByStableSceneHierarchy(Component[] components)
+        {
+            if (components == null || components.Length <= 1)
+                return;
+
+            var keys = new string[components.Length];
+            var sb = new StringBuilder(128);
+            for (int i = 0; i < components.Length; i++)
+            {
+                sb.Clear();
+                AppendStableHierarchySortKey(sb, components[i]);
+                keys[i] = sb.ToString();
+            }
+
+            Array.Sort(keys, components, StringComparer.Ordinal);
+        }
+
+        static void AppendStableHierarchySortKey(StringBuilder sb, Component c)
+        {
+            var scene = c.gameObject.scene;
+            sb.Append(scene.path);
+            sb.Append('\x1');
+            sb.Append(scene.buildIndex.ToString("D4"));
+            sb.Append('\x1');
+            var t = c.transform;
+            var indices = new List<int>(8);
+            while (t != null)
+            {
+                indices.Add(t.GetSiblingIndex());
+                t = t.parent;
+            }
+            for (int i = indices.Count - 1; i >= 0; i--)
+            {
+                if (i < indices.Count - 1)
+                    sb.Append('.');
+                sb.Append(indices[i].ToString("D8"));
+            }
+        }
+#endif
 
         Component[] GetTargets(Type type)
         {
@@ -959,8 +1004,9 @@ namespace UnityEngine.Formats.Alembic.Util
 
 #if UNITY_6000_4_OR_NEWER
             var objects = GameObject.FindObjectsByType(type);
-            Array.Sort(objects, (a, b) => EntityId.ToULong(a.GetEntityId()).CompareTo(EntityId.ToULong(b.GetEntityId())));
-            return Array.ConvertAll<UnityEngine.Object, Component>(objects, e => (Component)e);
+            var components = Array.ConvertAll<UnityEngine.Object, Component>(objects, e => (Component)e);
+            SortComponentsByStableSceneHierarchy(components);
+            return components;
 #elif UNITY_2023_1_OR_NEWER
             return Array.ConvertAll<UnityEngine.Object, Component>(GameObject.FindObjectsByType(type, FindObjectsSortMode.InstanceID), e => (Component)e);
 #else

--- a/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Exporter/AlembicExporter_impl.cs
@@ -967,7 +967,7 @@ namespace UnityEngine.Formats.Alembic.Util
         /// Deterministic order for export: loaded scene (path, build index), then hierarchy (sibling indices from root).
         /// Does not use InstanceID/EntityId ordering (see Unity 6+ engine guidance).
         /// </summary>
-        static void SortComponentsByStableSceneHierarchy(Component[] components)
+        internal static void SortComponentsByStableSceneHierarchy(Component[] components)
         {
             if (components == null || components.Length <= 1)
                 return;
@@ -984,7 +984,7 @@ namespace UnityEngine.Formats.Alembic.Util
             Array.Sort(keys, components, StringComparer.Ordinal);
         }
 
-        static void AppendStableHierarchySortKey(StringBuilder sb, Component c)
+        internal static void AppendStableHierarchySortKey(StringBuilder sb, Component c)
         {
             var scene = c.gameObject.scene;
             sb.Append(scene.path);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicMesh.cs
@@ -533,7 +533,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         internal static Material GetDefaultMaterial()
         {
-            var pipelineAsset = GraphicsSettings.renderPipelineAsset;
+            var pipelineAsset = GraphicsSettings.defaultRenderPipeline;
             if (pipelineAsset != null)
             {
                 return pipelineAsset.defaultMaterial;

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+#if UNITY_6000_4_OR_NEWER
+using System.Threading;
+#endif
 using Unity.Jobs;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -86,6 +89,13 @@ namespace UnityEngine.Formats.Alembic.Importer
         }
 
         static List<AlembicStream> s_streams = new List<AlembicStream>();
+
+#if UNITY_6000_4_OR_NEWER
+        // Native aiContext keys are int; use a monotonic surrogate instead of narrowing EntityId.
+        static int s_nextNativeContextUid;
+
+        static int AllocateNativeContextUid() => Interlocked.Increment(ref s_nextNativeContextUid);
+#endif
 
         public static void DisconnectStreamsWithPath(string path)
         {
@@ -223,7 +233,7 @@ namespace UnityEngine.Formats.Alembic.Importer
         {
             m_time = 0.0f;
 #if UNITY_6000_4_OR_NEWER
-            m_context = new SafeContext(aiContext.Create((int)EntityId.ToULong(m_abcTreeRoot.gameObject.GetEntityId())));
+            m_context = new SafeContext(aiContext.Create(AllocateNativeContextUid()));
 #else
             m_context = new SafeContext(aiContext.Create(m_abcTreeRoot.gameObject.GetInstanceID()));
 #endif

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -91,7 +91,10 @@ namespace UnityEngine.Formats.Alembic.Importer
         static List<AlembicStream> s_streams = new List<AlembicStream>();
 
 #if UNITY_6000_4_OR_NEWER
-        // Native aiContext keys are int; use a monotonic surrogate instead of narrowing EntityId.
+        // Native aiContext keys are int; use a monotonic surrogate instead of narrowing EntityId (ulong → int
+        // would silently discard the upper 32 bits). Starts at 0; Interlocked.Increment returns 1 on the
+        // first call, so UID 0 is never issued — matching GetInstanceID's guarantee for live objects.
+        // Theoretical int overflow after ~2 billion AbcLoad calls is impossible in practice.
         static int s_nextNativeContextUid;
 
         static int AllocateNativeContextUid() => Interlocked.Increment(ref s_nextNativeContextUid);

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/AlembicStream.cs
@@ -222,7 +222,11 @@ namespace UnityEngine.Formats.Alembic.Importer
         public bool AbcLoad(bool createMissingNodes, bool serializeMesh)
         {
             m_time = 0.0f;
+#if UNITY_6000_4_OR_NEWER
+            m_context = new SafeContext(aiContext.Create((int)EntityId.ToULong(m_abcTreeRoot.gameObject.GetEntityId())));
+#else
             m_context = new SafeContext(aiContext.Create(m_abcTreeRoot.gameObject.GetInstanceID()));
+#endif
 
             var settings = m_streamDesc.Settings;
             m_config.swapHandedness = settings.SwapHandedness;

--- a/com.unity.formats.alembic/Runtime/Scripts/Importer/Behaviours/AlembicCurvesRenderer.cs
+++ b/com.unity.formats.alembic/Runtime/Scripts/Importer/Behaviours/AlembicCurvesRenderer.cs
@@ -274,7 +274,7 @@ namespace UnityEngine.Formats.Alembic.Importer
 
         static Material GetDefaultMaterial()
         {
-            return GraphicsSettings.renderPipelineAsset != null ? GraphicsSettings.renderPipelineAsset.defaultMaterial : new Material(Shader.Find("Diffuse"));
+            return GraphicsSettings.defaultRenderPipeline != null ? GraphicsSettings.defaultRenderPipeline.defaultMaterial : new Material(Shader.Find("Diffuse"));
         }
     }
 }

--- a/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs
@@ -1,5 +1,6 @@
 #if UNITY_6000_4_OR_NEWER
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 using UnityEngine;
@@ -19,6 +20,9 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
         {
             AlembicRecorder.SortComponentsByStableSceneHierarchy(null);
             AlembicRecorder.SortComponentsByStableSceneHierarchy(new Component[0]);
+            var go = new GameObject("single");
+            AlembicRecorder.SortComponentsByStableSceneHierarchy(new Component[] { go.AddComponent<MeshRenderer>() });
+            Object.DestroyImmediate(go);
         }
 
         [UnityTest]
@@ -38,8 +42,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 
             var sbA = new StringBuilder();
             var sbB = new StringBuilder();
-            AlembicRecorder.AppendStableHierarchySortKey(sbA, a);
-            AlembicRecorder.AppendStableHierarchySortKey(sbB, b);
+            var scratchpad = new List<int>();
+            AlembicRecorder.AppendStableHierarchySortKey(sbA, a, scratchpad);
+            scratchpad.Clear();
+            AlembicRecorder.AppendStableHierarchySortKey(sbB, b, scratchpad);
 
             Assert.Less(string.CompareOrdinal(sbA.ToString(), sbB.ToString()), 0);
 
@@ -62,8 +68,10 @@ namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
 
             var sbP = new StringBuilder();
             var sbC = new StringBuilder();
-            AlembicRecorder.AppendStableHierarchySortKey(sbP, cParent);
-            AlembicRecorder.AppendStableHierarchySortKey(sbC, cChild);
+            var scratchpad = new List<int>();
+            AlembicRecorder.AppendStableHierarchySortKey(sbP, cParent, scratchpad);
+            scratchpad.Clear();
+            AlembicRecorder.AppendStableHierarchySortKey(sbC, cChild, scratchpad);
 
             Assert.Less(string.CompareOrdinal(sbP.ToString(), sbC.ToString()), 0);
 

--- a/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs
+++ b/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs
@@ -1,0 +1,103 @@
+#if UNITY_6000_4_OR_NEWER
+using System.Collections;
+using System.Text;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Formats.Alembic.Util;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace UnityEditor.Formats.Alembic.Exporter.UnitTests
+{
+    /// <summary>
+    /// Tests for deterministic export ordering (scene + hierarchy path), Unity 6.4+.
+    /// </summary>
+    class StableHierarchySortTests
+    {
+        [Test]
+        public void SortComponentsByStableSceneHierarchy_NullOrTrivial_DoesNotThrow()
+        {
+            AlembicRecorder.SortComponentsByStableSceneHierarchy(null);
+            AlembicRecorder.SortComponentsByStableSceneHierarchy(new Component[0]);
+        }
+
+        [UnityTest]
+        public IEnumerator AppendStableHierarchySortKey_SiblingOrderMatchesSiblingIndex()
+        {
+            var sceneName = "StableHierarchySortTests_" + System.Guid.NewGuid();
+            var scene = SceneManager.CreateScene(sceneName);
+            SceneManager.SetActiveScene(scene);
+
+            var first = new GameObject("first");
+            var second = new GameObject("second");
+            first.transform.SetSiblingIndex(0);
+            second.transform.SetSiblingIndex(1);
+
+            var a = first.AddComponent<MeshRenderer>();
+            var b = second.AddComponent<MeshRenderer>();
+
+            var sbA = new StringBuilder();
+            var sbB = new StringBuilder();
+            AlembicRecorder.AppendStableHierarchySortKey(sbA, a);
+            AlembicRecorder.AppendStableHierarchySortKey(sbB, b);
+
+            Assert.Less(string.CompareOrdinal(sbA.ToString(), sbB.ToString()), 0);
+
+            yield return SceneManager.UnloadSceneAsync(scene);
+        }
+
+        [UnityTest]
+        public IEnumerator AppendStableHierarchySortKey_ParentBeforeChild()
+        {
+            var sceneName = "StableHierarchySortTests_" + System.Guid.NewGuid();
+            var scene = SceneManager.CreateScene(sceneName);
+            SceneManager.SetActiveScene(scene);
+
+            var parent = new GameObject("parent");
+            var child = new GameObject("child");
+            child.transform.SetParent(parent.transform);
+
+            var cParent = parent.AddComponent<MeshRenderer>();
+            var cChild = child.AddComponent<MeshRenderer>();
+
+            var sbP = new StringBuilder();
+            var sbC = new StringBuilder();
+            AlembicRecorder.AppendStableHierarchySortKey(sbP, cParent);
+            AlembicRecorder.AppendStableHierarchySortKey(sbC, cChild);
+
+            Assert.Less(string.CompareOrdinal(sbP.ToString(), sbC.ToString()), 0);
+
+            yield return SceneManager.UnloadSceneAsync(scene);
+        }
+
+        [UnityTest]
+        public IEnumerator SortComponentsByStableSceneHierarchy_OrdersByHierarchy()
+        {
+            var sceneName = "StableHierarchySortTests_" + System.Guid.NewGuid();
+            var scene = SceneManager.CreateScene(sceneName);
+            SceneManager.SetActiveScene(scene);
+
+            var root = new GameObject("root");
+            var childA = new GameObject("a");
+            var childB = new GameObject("b");
+            childA.transform.SetParent(root.transform);
+            childB.transform.SetParent(root.transform);
+            childA.transform.SetSiblingIndex(0);
+            childB.transform.SetSiblingIndex(1);
+
+            var r = root.AddComponent<MeshRenderer>();
+            var a = childA.AddComponent<MeshRenderer>();
+            var b = childB.AddComponent<MeshRenderer>();
+
+            var components = new[] { b, r, a };
+            AlembicRecorder.SortComponentsByStableSceneHierarchy(components);
+
+            Assert.AreSame(r, components[0]);
+            Assert.AreSame(a, components[1]);
+            Assert.AreSame(b, components[2]);
+
+            yield return SceneManager.UnloadSceneAsync(scene);
+        }
+    }
+}
+#endif

--- a/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs.meta
+++ b/com.unity.formats.alembic/Tests/Runtime/StableHierarchySortTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 73af66f210dad064e93b2943baafc8b4

--- a/com.unity.formats.alembic/ValidationExceptions.json
+++ b/com.unity.formats.alembic/ValidationExceptions.json
@@ -1,9 +1,9 @@
 {
-    "ErrorExceptions": [   
+    "ErrorExceptions": [
         {
             "ValidationTest": "Package Unity Version Validation",
             "ExceptionMessage": "The Unity version requirement is more strict than in the previous version of the package. Increment the minor version of the package to leave patch versions available for previous version. Read more about this error and potential solutions at https://docs.unity3d.com/Packages/com.unity.package-validation-suite@latest/index.html?preview=1&subfolder=/manual/package_unity_version_validation_error.html#the-unity-version-requirement-is-more-strict-than-in-the-previous-version-of-the-package",
-            "PackageVersion": "2.4.4"
+            "PackageVersion": "2.4.5"
         }
     ],
     "WarningExceptions": []

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -16,5 +16,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2021.3",
-  "version": "2.4.4"
+  "version": "2.4.5"
 }


### PR DESCRIPTION
## Purpose of this PR

**Ticket/Jira #:** [UUM-137643](https://jira.unity3d.com/browse/UUM-137643)

<!-- Description of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more. -->

This PR address 3 issues:

### 1 - Compilation errors in the console
`error CS0619: 'Object.GetInstanceID()' is obsolete: 'GetInstanceID is deprecated. Use GetEntityId instead.`

### 2 - Warnings (that will become errors in a foreseeable futur):
`warning CS0618: 'FindObjectsSortMode' is obsolete: 'FindObjectsSortMode has been deprecated. Use the FindObjectsByType overloads that do not take a FindObjectsSortMode parameter.' 
`
⚠️ In previous versions of the code, a sorting by FindObjectsSortMode.instanceID was used to have the determinism needed for UpdateCaptureNodes. But that was an inconsistant way of sorting. Furthermore, with entityID, the small amount of creation-order semantics that were accidentally present in instanceID is removed. That's why this PR instroduces another way of sorting with determinism (cf `SortComponentsByStableSceneHierarchy`).

### 3- replace renderPipelineAsset by defaultRenderPipeline
defautRenderPipeline was introduced in 2019 stream so that was due.


A general mindset for this PR is the less we touch, the better. 
The reason is that this code is very legacy and in basic support. We want to mitigate the risk of breaking the past versions and increase our support load. 
That's why every changes needed were encapsulated in `#if UNITY_6000_4_OR_NEWER...#endif` even when the changes would be considered a better practice for precedent versions too (like not sorting with instanceIds). 

## Testing

**Functional Testing status:**

<!-- Explanation of what's tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.  -->

**Performance Testing status:**

<!-- Could this PR affect performance? If so, what has been done to measure time taken / memory used etc? Can include new or existing performance tests. Also see [Ensuring Performance by Default](https://confluence.unity3d.com/display/DEV/Ensuring+Performance+by+Default). -->

## Overall Product Risks
<!-- See Testing Status, Complexity and Halo Effect for your PR](https://confluence.unity3d.com/display/DEV/Testing+Status%2C+Complexity+and+Halo+Effect+for+your+PR). -->

**Complexity:**
<!-- (Minimal / Low / Medium / High) -->

**Halo Effect:**
<!-- (Minimal / Low / Medium / High) -->

## Documentation & UX Writing

<!-- Indicate here what kind of review you need from a Technical writer. Feel free to precise what to focus on and give context as needed. -->

| User facing text to review | <!-- Y/N --> | Details |
| :--- | :--- | :--- |
| User interface |  |  |
| Public API docs |  |  |
| Changelog |  |  |

<!-- Technical writer may update this section, for example to define if yes or no the user manual or any other documentation needs to be updated, and link to a JIRA documentation ticket if the answer is yes. If you don't know, just put a question mark.-->

| Documentation halo effect | <!-- Y/N/? --> | Jira link |
| :--- | :--- | :--- |
| User manual |  |  |
| Other docs |  |  |

## Additional information

**Note to reviewers:**

<!-- Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context. -->

**Reminder:**
<!-- Things to remember to do before finalizing this PR. -->
- [x] Add entry in CHANGELOG.md <!-- Remove if not applicable. -->
- [x] check defaultRenderPipeline availability - Was introduced as early as 2019.4 so before our minimal supported version (21.3)
- [x] Wait for Recorder 5.1.6 to be released (see [UUM-137641](https://jira.unity3d.com/browse/UUM-137641) - Cf Recorder tests
- [x] Sanity check QA - test import + export both for local and streamed assets with depth
