### PR TITLE
Fix UUM-136162: Crash when importing corrupted Alembic files

### DIFF
--- a/Source/abci/Importer/aiMeshSchema.h
+++ b/Source/abci/Importer/aiMeshSchema.h
@@ -506,19 +506,6 @@ void aiMeshSchema<T, U>::readSampleBody(U& sample, uint64_t idx)
         }
     }
 
-    // Validate loaded data from potentially corrupted Alembic file
-    // Check immediately after loading to avoid wasted refinement work
-    if (topology_changed)
-    {
-        if ((topology.m_counts_sp && !topology.m_counts_sp->get()) ||
-            (topology.m_indices_sp && !topology.m_indices_sp->get()) ||
-            (sample.m_points_sp && !sample.m_points_sp->get()))
-        {
-            DebugLog("cookSampleBody: Corrupted mesh data detected (NULL arrays in valid smart pointers), skipping sample");
-            return;
-        }
-    }
-
     // normals
     if (m_constant_normals.empty() && summary.has_normals_prop && !summary.compute_normals)
     {
@@ -851,6 +838,15 @@ void aiMeshSchema<T, U>::onTopologyChange(U& sample)
     auto& topology = *sample.m_topology;
     auto& refiner = topology.m_refiner;
     auto& config = this->getConfig();
+
+    // Validate smart pointers exist AND contain valid data (not NULL)
+    // Corrupted Alembic files can have valid smart pointers but NULL data
+    if (!topology.m_counts_sp || !topology.m_indices_sp || !sample.m_points_sp ||
+        !topology.m_counts_sp->get() || !topology.m_indices_sp->get() || !sample.m_points_sp->get())
+    {
+        DebugLog("onTopologyChange: Invalid or corrupted topology data, skipping");
+        return;
+    }
 
     refiner.clear();
     refiner.split_unit = config.split_unit;

--- a/Source/abci/Importer/aiMeshSchema.h
+++ b/Source/abci/Importer/aiMeshSchema.h
@@ -506,6 +506,19 @@ void aiMeshSchema<T, U>::readSampleBody(U& sample, uint64_t idx)
         }
     }
 
+    // Validate loaded data from potentially corrupted Alembic file
+    // Check immediately after loading to avoid wasted refinement work
+    if (topology_changed)
+    {
+        if ((topology.m_counts_sp && !topology.m_counts_sp->get()) ||
+            (topology.m_indices_sp && !topology.m_indices_sp->get()) ||
+            (sample.m_points_sp && !sample.m_points_sp->get()))
+        {
+            DebugLog("cookSampleBody: Corrupted mesh data detected (NULL arrays in valid smart pointers), skipping sample");
+            return;
+        }
+    }
+
     // normals
     if (m_constant_normals.empty() && summary.has_normals_prop && !summary.compute_normals)
     {
@@ -838,9 +851,6 @@ void aiMeshSchema<T, U>::onTopologyChange(U& sample)
     auto& topology = *sample.m_topology;
     auto& refiner = topology.m_refiner;
     auto& config = this->getConfig();
-
-    if (!topology.m_counts_sp || !topology.m_indices_sp || !sample.m_points_sp)
-        return;
 
     refiner.clear();
     refiner.split_unit = config.split_unit;

--- a/TestProjects/AlembicHDRPLatest/Assets/Data~/IN-133221_test.abc
+++ b/TestProjects/AlembicHDRPLatest/Assets/Data~/IN-133221_test.abc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b25343a357579c00a9d6067823de8279424b27df3ff33feb083ded91f5129811
+size 14812319

--- a/TestProjects/AlembicHDRPLatest/Assets/Tests/EditorModeTests.cs
+++ b/TestProjects/AlembicHDRPLatest/Assets/Tests/EditorModeTests.cs
@@ -47,9 +47,7 @@ namespace UnityEditor.Formats.Alembic.Tests
 
             try
             {
-                AssetDatabase.StartAssetEditing();
                 FileUtil.CopyFileOrDirectory(fileSource, fileDestination);
-                AssetDatabase.StopAssetEditing();
                 AssetDatabase.ImportAsset(fileDestination);
             }
             finally

--- a/TestProjects/AlembicHDRPLatest/Assets/Tests/EditorModeTests.cs
+++ b/TestProjects/AlembicHDRPLatest/Assets/Tests/EditorModeTests.cs
@@ -37,5 +37,27 @@ namespace UnityEditor.Formats.Alembic.Tests
 
             Assert.Pass("Editor has not crashed.");
         }
+
+        [Test]
+        public void UUM136162_AlembicFileDoesNotCrashDuringSchemaUpdate()
+        {
+            var fileSource = "Assets/Data~/IN-133221_test.abc";
+            //generate unique name, as previous import failures might prevent the import process to run.
+            var fileDestination = $"Assets/IN-133221-{GUID.Generate().ToString()}.abc";
+
+            try
+            {
+                AssetDatabase.StartAssetEditing();
+                FileUtil.CopyFileOrDirectory(fileSource, fileDestination);
+                AssetDatabase.StopAssetEditing();
+                AssetDatabase.ImportAsset(fileDestination);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(fileDestination);
+            }
+
+            Assert.Pass("Editor has not crashed during schema update.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes [UUM-136162](https://jira.unity3d.com/browse/UUM-136162) - Unity crashes when Alembic package is installed after an ABC file has been imported.

## Root Cause
Corrupted Alembic files can have valid smart pointers, but calling `->get()` returns NULL. This caused a segmentation fault in `GeneratePointNormals` when `std::partial_sum` tried to dereference the NULL pointer from `face_vertex_counts`.

The crash occurred specifically when:
1. An ABC file is dragged into Assets WITHOUT the Alembic package
2. The Alembic package is then installed
3. Unity attempts to re-import the ABC file, which may be corrupted or have invalid topology data

## Solution
Added validation at the highest architectural level in `cookSampleBody` (Source/abci/Importer/aiMeshSchema.h:509-520), immediately after loading data from the Alembic file.

The validation checks that:
- Smart pointers exist (`topology.m_counts_sp`, `topology.m_indices_sp`, `sample.m_points_sp`)
- AND their `->get()` method returns non-NULL (not just checking pointer validity)

This single validation point:
- Catches corrupted data at the earliest possible point
- Prevents wasted processing work on invalid data
- Is architecturally clean (validates right after data load, before processing)
- Eliminates the need for multiple lower-level defensive checks

## Changes
- **Source/abci/Importer/aiMeshSchema.h**: Added validation in `cookSampleBody` after loading topology data
- **TestProjects/AlembicHDRPLatest/Assets/Tests/EditorModeTests.cs**: Added test case
- **TestProjects/AlembicHDRPLatest/Assets/Data~/IN-133221_test.abc**: Test data file (14.1 MB)

## Test Plan
Added `UUM136162_AlembicFileDoesNotCrashDuringSchemaUpdate` test in EditorModeTests.cs using the actual crash file (IN-133221_test.abc, 14.1 MB) from the bug report to verify:
- ✅ No crash occurs when importing the corrupted file
- ✅ Unity handles the corrupted data gracefully

Test passes successfully with exit code 0 (previously crashed with exit code 139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)