### PR TITLE
Fix ARM64 abci.dll incorrectly included in non-ARM64 builds

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed the Windows ARM64 native plugin being incorrectly included in non-ARM64 player builds (such as GameCore x64), where it failed to load with an architecture mismatch.
+
 ## [2.4.5] - 2026-06-03
 ### Changed
 - Update deprecated and obsolete APIs available in Unity 6000.4 and above.

--- a/com.unity.formats.alembic/Runtime/Plugins/ARM64/abci.dll.meta
+++ b/com.unity.formats.alembic/Runtime/Plugins/ARM64/abci.dll.meta
@@ -22,30 +22,30 @@ PluginImporter:
         Exclude Win: 1
         Exclude Win64: 0
   - first:
-      Any: 
+      Any:
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: ARM64
         DefaultValueInitialized: true
         OS: Windows
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: x86_64
+        CPU: None
   - first:
       Standalone: Win
     second:


### PR DESCRIPTION
## Problem

`Runtime/Plugins/ARM64/abci.dll.meta` had **"Any Platform" enabled**. With Any Platform on, Unity includes the plugin in every platform not explicitly listed in the `: Any` *Exclude* set, and the per-platform `enabled` flags (including the intended `Standalone: Win64 → CPU: ARM64` restriction) are ignored.

As a result the **ARM64 binary was bundled into non-ARM64 builds** (e.g. GameCore x64, Win64 x64, Linux64, OSXUniversal). In GameCore (x64) builds it then failed to load:

> the ARM64 dll fails to load with expected x64 architecture, but was ARM64

Reported by a user against 2.4.5.

## Root cause

Introduced in #573 (ARM64 support, ABC-436). The `.meta` was added with `Any: enabled: 1` and has never been modified since, so every release shipping ARM64 support is affected — it is not a 2.4.5-specific regression.

## Fix

Disable "Any Platform" and restrict the plugin to **Win64 / ARM64 only**, matching how the other native libs (`x86_64/abci.dll`, `abci.bundle`, `abci.so`) are configured:

| Setting | Before | After |
|---------|--------|-------|
| Any Platform | `enabled: 1` | `enabled: 0` |
| Editor | `CPU: AnyCPU`, OS Windows | `CPU: ARM64`, OS Windows |
| Standalone Linux64 | `enabled: 1` | `enabled: 0` |
| Standalone OSXUniversal | `enabled: 1` | `enabled: 0` |
| Standalone Win64 | `enabled: 1, CPU: ARM64` | _(unchanged)_ |

The Editor entry is scoped to `CPU: ARM64` / `OS: Windows` (matching the OS/CPU-scoping pattern of the other native libs) so an ARM64 Windows editor loads this dll while the x64 editor continues to use `x86_64/abci.dll`.

## Verification

- Opened the AlembicHDRP test project (2021.3.45f1) in batch mode: the importer accepts the `.meta` **unchanged** (no rewrite/normalization) and reports no plugin import errors.
- Note: verified on Apple-Silicon macOS, so the Windows-ARM64/GameCore platform resolution itself is left to CI's Windows build/validation jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)