### PR TITLE
Backport from release/2.4.6

### DIFF
--- a/.yamato/wrench/api-validation-jobs.yml
+++ b/.yamato/wrench/api-validation-jobs.yml
@@ -60,8 +60,8 @@ api_validation_-_formats_alembic_-_2021_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -33,5 +33,5 @@ package_pack_-_formats_alembic:
     UPMCI_ACK_LARGE_PACKAGE: 1
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -16,18 +16,18 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_macos13
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_win10
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_macos13
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_ubuntu2204
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_win10
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_macos13
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_win10
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_macos13arm
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_win10
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_macos13arm
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_ubuntu2204
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_win10
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (MacOS).
 preview_apv_-_6000_0_-_macos13:
@@ -82,10 +82,10 @@ preview_apv_-_6000_0_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Ubuntu).
 preview_apv_-_6000_0_-_ubuntu2204:
@@ -140,10 +140,10 @@ preview_apv_-_6000_0_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Windows).
 preview_apv_-_6000_0_-_win10:
@@ -199,10 +199,10 @@ preview_apv_-_6000_0_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (MacOS).
 preview_apv_-_6000_3_-_macos13:
@@ -257,10 +257,10 @@ preview_apv_-_6000_3_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Ubuntu).
 preview_apv_-_6000_3_-_ubuntu2204:
@@ -315,10 +315,10 @@ preview_apv_-_6000_3_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.3 manifest (Windows).
 preview_apv_-_6000_3_-_win10:
@@ -374,185 +374,10 @@ preview_apv_-_6000_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
-# Functional tests for dependents found in the latest 6000.4 manifest (MacOS).
-preview_apv_-_6000_4_-_macos13:
-  name: Preview APV - 6000.4 - macos13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
-# Functional tests for dependents found in the latest 6000.4 manifest (Ubuntu).
-preview_apv_-_6000_4_-_ubuntu2204:
-  name: Preview APV - 6000.4 - ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
-# Functional tests for dependents found in the latest 6000.4 manifest (Windows).
-preview_apv_-_6000_4_-_win10:
-  name: Preview APV - 6000.4 - win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: python PythonScripts/editor_manifest_validator.py --version=6000.4 --wrench-config=.yamato/wrench/wrench_config.json
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (MacOS).
 preview_apv_-_6000_5_-_macos13:
@@ -607,10 +432,10 @@ preview_apv_-_6000_5_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (Ubuntu).
 preview_apv_-_6000_5_-_ubuntu2204:
@@ -665,10 +490,10 @@ preview_apv_-_6000_5_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.5 manifest (Windows).
 preview_apv_-_6000_5_-_win10:
@@ -724,10 +549,10 @@ preview_apv_-_6000_5_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (MacOS).
 preview_apv_-_6000_6_-_macos13arm:
@@ -745,7 +570,7 @@ preview_apv_-_6000_6_-_macos13arm:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast --arch arm64
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -783,10 +608,10 @@ preview_apv_-_6000_6_-_macos13arm:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (Ubuntu).
 preview_apv_-_6000_6_-_ubuntu2204:
@@ -803,7 +628,7 @@ preview_apv_-_6000_6_-_ubuntu2204:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -841,10 +666,10 @@ preview_apv_-_6000_6_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Functional tests for dependents found in the latest 6000.6 manifest (Windows).
 preview_apv_-_6000_6_-_win10:
@@ -862,7 +687,7 @@ preview_apv_-_6000_6_-_win10:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -900,8 +725,184 @@ preview_apv_-_6000_6_-_win10:
     UNITY_LICENSING_SERVER_DELETE_NUL: 0
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (MacOS).
+preview_apv_-_6000_7_-_macos13arm:
+  name: Preview APV - 6000.7 - macos13arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (Ubuntu).
+preview_apv_-_6000_7_-_ubuntu2204:
+  name: Preview APV - 6000.7 - ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (Windows).
+preview_apv_-_6000_7_-_win10:
+  name: Preview APV - 6000.7 - win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: python PythonScripts/editor_manifest_validator.py --version=6000.7 --wrench-config=.yamato/wrench/wrench_config.json
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
 

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -121,36 +121,6 @@ publish_dry_run_formats_alembic:
       UTR:
         location: results/UTR/validate-formats.alembic-6000.3-win10
         unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_macos13
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-macos13
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-macos13
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_ubuntu2204
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-ubuntu2204
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-ubuntu2204
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_win10
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-win10
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-win10
-        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_5_-_macos13
     specific_options:
       packages:
@@ -211,12 +181,42 @@ publish_dry_run_formats_alembic:
       UTR:
         location: results/UTR/validate-formats.alembic-6000.6-win10
         unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_macos13arm
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-macos13arm
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-macos13arm
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_ubuntu2204
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-ubuntu2204
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-ubuntu2204
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_win10
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-win10
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-win10
+        unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 
 # Publish  for formats.alembic to https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-npm
 publish_formats_alembic:
@@ -333,36 +333,6 @@ publish_formats_alembic:
       UTR:
         location: results/UTR/validate-formats.alembic-6000.3-win10
         unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_macos13
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-macos13
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-macos13
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_ubuntu2204
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-ubuntu2204
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-ubuntu2204
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_4_-_win10
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-formats.alembic-6000.4-win10
-        unzip: true
-      UTR:
-        location: results/UTR/validate-formats.alembic-6000.4-win10
-        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_5_-_macos13
     specific_options:
       packages:
@@ -423,11 +393,41 @@ publish_formats_alembic:
       UTR:
         location: results/UTR/validate-formats.alembic-6000.6-win10
         unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_macos13arm
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-macos13arm
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-macos13arm
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_ubuntu2204
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-ubuntu2204
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-ubuntu2204
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_formats_alembic_-_6000_7_-_win10
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-formats.alembic-6000.7-win10
+        unzip: true
+      UTR:
+        location: results/UTR/validate-formats.alembic-6000.7-win10
+        unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   allow_on: branch match "^release/.*"
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 

--- a/.yamato/wrench/recipe-regeneration.yml
+++ b/.yamato/wrench/recipe-regeneration.yml
@@ -31,5 +31,5 @@ test_-_wrench_jobs_up_to_date:
     cancel_old_ci: true
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
 

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -70,10 +70,10 @@ validate_-_formats_alembic_-_2021_3_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -141,10 +141,10 @@ validate_-_formats_alembic_-_2021_3_-_ubuntu1804:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -212,10 +212,10 @@ validate_-_formats_alembic_-_2021_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -283,10 +283,10 @@ validate_-_formats_alembic_-_6000_0_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -354,10 +354,10 @@ validate_-_formats_alembic_-_6000_0_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -425,10 +425,10 @@ validate_-_formats_alembic_-_6000_0_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -496,10 +496,10 @@ validate_-_formats_alembic_-_6000_3_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -567,10 +567,10 @@ validate_-_formats_alembic_-_6000_3_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -638,223 +638,10 @@ validate_-_formats_alembic_-_6000_3_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:formats.alembic
-
-# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.4 - macos13 (6000.4 - MacOS).
-validate_-_formats_alembic_-_6000_4_-_macos13:
-  name: Validate - formats.alembic - 6000.4 - macos13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: 'echo { "disableBatchMode": true } > test-formats.alembic/TestRunnerOptions.json'
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 20
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-formats.alembic/Logs/**
-      - test-formats.alembic/Library/*.log
-      - test-formats.alembic/*.log
-      - test-formats.alembic/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:formats.alembic
-
-# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.4 - ubuntu2204 (6000.4 - Ubuntu).
-validate_-_formats_alembic_-_6000_4_-_ubuntu2204:
-  name: Validate - formats.alembic - 6000.4 - ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: 'echo { "disableBatchMode": true } > test-formats.alembic/TestRunnerOptions.json'
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 20
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-formats.alembic/Logs/**
-      - test-formats.alembic/Library/*.log
-      - test-formats.alembic/*.log
-      - test-formats.alembic/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:formats.alembic
-
-# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.4 - win10 (6000.4 - Windows).
-validate_-_formats_alembic_-_6000_4_-_win10:
-  name: Validate - formats.alembic - 6000.4 - win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: 'echo ^{ ^"disableBatchMode^": true ^} > test-formats.alembic/TestRunnerOptions.json'
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: 'UnifiedTestRunner.exe --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
-    timeout: 20
-    retries: 1
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-formats.alembic/Logs/**
-      - test-formats.alembic/Library/*.log
-      - test-formats.alembic/*.log
-      - test-formats.alembic/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -922,10 +709,10 @@ validate_-_formats_alembic_-_6000_5_-_macos13:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -993,10 +780,10 @@ validate_-_formats_alembic_-_6000_5_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
@@ -1064,16 +851,230 @@ validate_-_formats_alembic_-_6000_5_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
 # PVP Editor and Playmode tests for Validate - formats.alembic - 6000.6 - macos13arm (6000.6 - MacOS).
 validate_-_formats_alembic_-_6000_6_-_macos13arm:
   name: Validate - formats.alembic - 6000.6 - macos13arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast --arch arm64
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: 'echo { "disableBatchMode": true } > test-formats.alembic/TestRunnerOptions.json'
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-formats.alembic/Logs/**
+      - test-formats.alembic/Library/*.log
+      - test-formats.alembic/*.log
+      - test-formats.alembic/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
+  labels:
+  - Packages:formats.alembic
+
+# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.6 - ubuntu2204 (6000.6 - Ubuntu).
+validate_-_formats_alembic_-_6000_6_-_ubuntu2204:
+  name: Validate - formats.alembic - 6000.6 - ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: 'echo { "disableBatchMode": true } > test-formats.alembic/TestRunnerOptions.json'
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-formats.alembic/Logs/**
+      - test-formats.alembic/Library/*.log
+      - test-formats.alembic/*.log
+      - test-formats.alembic/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
+  labels:
+  - Packages:formats.alembic
+
+# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.6 - win10 (6000.6 - Windows).
+validate_-_formats_alembic_-_6000_6_-_win10:
+  name: Validate - formats.alembic - 6000.6 - win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-formats.alembic --packages "upm-ci~/packages/*.tgz" --filter "com.unity.formats.alembic com.unity.formats.alembic.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: 'echo ^{ ^"disableBatchMode^": true ^} > test-formats.alembic/TestRunnerOptions.json'
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported -PVP-41-1 .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner.exe --testproject=test-formats.alembic --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-formats.alembic/Logs/**
+      - test-formats.alembic/Library/*.log
+      - test-formats.alembic/*.log
+      - test-formats.alembic/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_formats_alembic
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.3.0.0
+  labels:
+  - Packages:formats.alembic
+
+# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.7 - macos13arm (6000.7 - MacOS).
+validate_-_formats_alembic_-_6000_7_-_macos13arm:
+  name: Validate - formats.alembic - 6000.7 - macos13arm
   agent:
     image: package-ci/macos-13-arm64:v4
     type: Unity::VM::osx
@@ -1136,16 +1137,16 @@ validate_-_formats_alembic_-_6000_6_-_macos13arm:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
-# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.6 - ubuntu2204 (6000.6 - Ubuntu).
-validate_-_formats_alembic_-_6000_6_-_ubuntu2204:
-  name: Validate - formats.alembic - 6000.6 - ubuntu2204
+# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.7 - ubuntu2204 (6000.7 - Ubuntu).
+validate_-_formats_alembic_-_6000_7_-_ubuntu2204:
+  name: Validate - formats.alembic - 6000.7 - ubuntu2204
   agent:
     image: package-ci/ubuntu-22.04:v4
     type: Unity::VM
@@ -1207,16 +1208,16 @@ validate_-_formats_alembic_-_6000_6_-_ubuntu2204:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 
-# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.6 - win10 (6000.6 - Windows).
-validate_-_formats_alembic_-_6000_6_-_win10:
-  name: Validate - formats.alembic - 6000.6 - win10
+# PVP Editor and Playmode tests for Validate - formats.alembic - 6000.7 - win10 (6000.7 - Windows).
+validate_-_formats_alembic_-_6000_7_-_win10:
+  name: Validate - formats.alembic - 6000.7 - win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM
@@ -1278,10 +1279,10 @@ validate_-_formats_alembic_-_6000_6_-_win10:
     UNITY_LICENSING_SERVER_DELETE_ULF: 0
     UNITY_LICENSING_SERVER_TOOLSET: pro
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+    UPMPVP_CONTEXT_WRENCH: 3.3.0.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
+    Wrench: 3.3.0.0
   labels:
   - Packages:formats.alembic
 

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -39,7 +39,7 @@
   },
   "publishing_job": ".yamato/wrench/promotion-jobs.yml#publish_formats_alembic",
   "branch_pattern": "ReleaseSlash",
-  "wrench_version": "2.12.0.0",
+  "wrench_version": "3.3.0.0",
   "pvp_exemption_path": ".yamato/wrench/pvp-exemptions.json",
   "cs_project_path": "Tools/CI/Alembic.Cookbook.csproj"
 }

--- a/Tools/CI/Alembic.Cookbook.csproj
+++ b/Tools/CI/Alembic.Cookbook.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="2.12.0" />
+      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="3.3.0" />
     </ItemGroup>
 
 </Project>

--- a/Tools/CI/Recipes/BuildAlembicPlugins.cs
+++ b/Tools/CI/Recipes/BuildAlembicPlugins.cs
@@ -39,8 +39,13 @@ public class BuildAlembicPlugins : RecipeBase
         List<IJobBuilder> builders = new();
         foreach (var agent in buildAgents)
         {
+            var arch = agent.Image.Contains("arm64") ? Architecture.Arm64 : Architecture.x64;
+            HostPlatform host = agent.Image.Contains("win") ? HostPlatform.Windows
+                : agent.Image.Contains("mac") ? HostPlatform.MacOS
+                : HostPlatform.CentOS;
+            var target = new TargetPlatform(host.Name, arch);
             var builder = JobBuilder.Create(GetJobName(agent))
-                .WithPlatform(new Platform(agent, SystemType.Unknown))
+                .WithPlatform(new Platform(agent, host, target))
                 .WithDescription(GetJobName(agent));
 
             if (agent.Image.Contains("win"))

--- a/Tools/CI/Recipes/CodeSigning.cs
+++ b/Tools/CI/Recipes/CodeSigning.cs
@@ -29,7 +29,7 @@ public class CodeSigning : RecipeBase
 
     public string GetJobName(Platform platform, string packageName)
     {
-        return $"Sign binaries for {packageName} on {platform.System.AsString()}";
+        return $"Sign binaries for {packageName} on {platform.Host.Name}";
     }
 
     public IEnumerable<Dependency> AsDependencies()
@@ -46,7 +46,7 @@ public class CodeSigning : RecipeBase
             var packageName = package.Value.ShortName;
             foreach (var platform in platforms)
             {
-                if (platform.System != SystemType.MacOS && platform.System != SystemType.Windows)
+                if (!platform.Host.IsMac && !platform.Host.IsWindows)
                 {
                     continue;
                 }
@@ -74,25 +74,26 @@ public class CodeSigning : RecipeBase
             .WithDescription(GetJobName(platform, packageName))
             .WithPlatform(platform);
 
-        switch (platform.System)
+        if (platform.Host.IsMac)
         {
-            case SystemType.MacOS:
-                job.WithCodeSigningCommands(platform, alembicBinariesToSignOnMac)
-                    .WithDependencies(
-                        new Dependency("BuildAlembicPlugins", "build_plugins_-_macos-12")
-                        )
-                    .WithArtifact(new Artifact($"{packageName}_SignedBinariesOnMac", $"{alembicBinariesToSignOnMac}/**"));
-                break;
-            case SystemType.Windows:
-                job.WithCodeSigningCommands(platform, alembicCodeSignListFileWindows)
-                    .WithDependencies(
-                        new Dependency("BuildAlembicPlugins", "build_plugins_-_win10"),
-                        new Dependency("BuildAlembicPlugins", "build_plugins_-_win11-arm64")
-                        )
-                    .WithArtifact(new Artifact($"{packageName}_SignedBinariesOnWindows", alembicBinariesToSignOnWin));
-                break;
-            default:
-                return null;
+            job.WithCodeSigningCommands(platform, alembicBinariesToSignOnMac)
+                .WithDependencies(
+                    new Dependency("BuildAlembicPlugins", "build_plugins_-_macos-12")
+                    )
+                .WithArtifact(new Artifact($"{packageName}_SignedBinariesOnMac", $"{alembicBinariesToSignOnMac}/**"));
+        }
+        else if (platform.Host.IsWindows)
+        {
+            job.WithCodeSigningCommands(platform, alembicCodeSignListFileWindows)
+                .WithDependencies(
+                    new Dependency("BuildAlembicPlugins", "build_plugins_-_win10"),
+                    new Dependency("BuildAlembicPlugins", "build_plugins_-_win11-arm64")
+                    )
+                .WithArtifact(new Artifact($"{packageName}_SignedBinariesOnWindows", alembicBinariesToSignOnWin));
+        }
+        else
+        {
+            return null;
         }
         return job;
     }

--- a/Tools/CI/Recipes/Extensions/JobBuilderExtensions.cs
+++ b/Tools/CI/Recipes/Extensions/JobBuilderExtensions.cs
@@ -16,9 +16,8 @@ internal static class JobBuilderExtensions
     /// <returns>The updated job builder with the code signing commands.</returns>
     public static IJobBuilder WithCodeSigningCommands(this IJobBuilder job, Platform platform, string binariesToSign)
     {
-        switch (platform.System)
+        if (platform.Host.IsMac)
         {
-            case SystemType.MacOS:
                 job.WithCommands(c => c
                         .AddBrick("git@github.cds.internal.unity3d.com:unity/macos.cds.ci.code-signing.git@v2.0.8",
                             ("CERTIFICATE_NAME", "apple-developer-id-application-unity-technologies-sf")))
@@ -28,17 +27,19 @@ internal static class JobBuilderExtensions
                          .WithLine("security lock-keychain /Users/$USER/Library/Keychains/login.keychain-db")
                          .WithLine($"codesign --verify --verbose {binariesToSign}")
                     );
-                break;
-            case SystemType.Windows:
+        }
+        else if (platform.Host.IsWindows)
+        {
                 job.WithCommands(c => c
                     .AddBrick("git@github.cds.internal.unity3d.com:unity/batch.cds.ci.code-signing.git@v2.0.8",
                         ("AZURE_VAULT_URI", "https://unity-cs-kv-euw1-prd.vault.azure.net/"),
                         ("AZURE_CERTIFICATE", "ev-unity-technologies-sf"),
                         ("FILE_LIST", $"{binariesToSign}"))
                     .Add($"python Tools/Scripts/verify_win_executables_signed.py --architecture x64 --codesign-list-file {binariesToSign}"));
-                break;
-            default:
-                return null;
+        }
+        else
+        {
+            return null;
         }
         return job;
     }

--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.6] - 2026-06-30
 ### Fixed
 - Fixed the Windows ARM64 native plugin being incorrectly included in non-ARM64 player builds (such as GameCore x64), where it failed to load with an architecture mismatch.
 

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -16,5 +16,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2021.3",
-  "version": "2.4.5"
+  "version": "2.4.6"
 }


### PR DESCRIPTION
Backport the release-branch changes from `release/2.4.6` into `main`, following the same process as #625 / #631.

Brings the following onto `main`:

- **Update Wrench to 3.3.0 and regenerate CI** (`770934af`) — migrates the recipe code from the deprecated `SystemType` Platform API to `HostPlatform`/`TargetPlatform` (RecipeEngine 3.x / Api 15.0.0) and regenerates `.yamato/wrench/*`. Build/sign job YAML is byte-identical; changes are the Wrench version stamp and the editor matrix (drops 6000.4, adds 6000.7). This is the upgrade required to start promotions.
- **Prepare 2.4.6 release** (`3f136ccb`) — `package.json` → 2.4.6 and CHANGELOG `[Unreleased]` → `[2.4.6]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)