### PR TITLE
Backport from release/2.4.7

### DIFF
--- a/com.unity.formats.alembic/CHANGELOG.md
+++ b/com.unity.formats.alembic/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.7] - 2026-07-10
 ### Changed
 - Empty/zero-face Alembic test fixtures are now imported only within their tests instead of on project load, so loading the package's tests no longer emits console log messages on internal CI.
 

--- a/com.unity.formats.alembic/package.json
+++ b/com.unity.formats.alembic/package.json
@@ -16,5 +16,5 @@
   ],
   "name": "com.unity.formats.alembic",
   "unity": "2021.3",
-  "version": "2.4.6"
+  "version": "2.4.7"
 }


### PR DESCRIPTION
Backport the release-branch changes from `release/2.4.7` into `main`, following the same process as #625 / #631 / #633.

Brings onto `main`:
- **Prepare 2.4.7 release** (`06fe19f1`) — `package.json` → 2.4.7 and CHANGELOG `[Unreleased]` → `[2.4.7]` (the zero-face test-fixture change that shipped in 2.4.7).

2.4.7 has been published and promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)